### PR TITLE
Example LSTM running with salinity data

### DIFF
--- a/lstm_modeling/run_salinity_lstm.py
+++ b/lstm_modeling/run_salinity_lstm.py
@@ -5,10 +5,8 @@
 
 # Load appropriate libraries/modules
 import torch
-from torch import nn, optim
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 from sklearn.preprocessing import MinMaxScaler
 from datetime import datetime
@@ -19,14 +17,69 @@ import salinity_lstm
 
 ##### Load and process the data #####
 
-data = sns.load_dataset("flights")
-data.passengers = data.passengers.astype(np.float32) # Convert passenger data to float for PyTorch
-data.month = data.month.apply(lambda x: datetime.strptime(x, '%b').month)
+##### FLIGHT DATA EXAMPLE #####
+
+# Create a dummy dataset where there is a categorical value
+# 'airline'. Can use this as a way to test getting a gage
+# site to work once I move to salinity.
+data1 = sns.load_dataset("flights")
+data1['airline'] = 'american'
+data2 = sns.load_dataset("flights")
+data2['airline'] = 'delta'
+data2.passengers = data2.passengers + np.random.randint(-50,100,size=len(data2.passengers))
+
+# Visualize this data
+plt.figure(figsize=[12., 5.])
+plt.plot(data1.index, data1.passengers, 'b--', label='American', )
+plt.plot(data2.index, data2.passengers, 'r--', label='Delta', )
+
+data_airlines = pd.concat([data1, data2])
+data_airlines['value'] = data_airlines.passengers.astype(np.float32) # Convert passenger data to float for PyTorch
+data_airlines.month = data_airlines.month.apply(lambda x: datetime.strptime(x, '%b').month) # Convert months into numeric
 
 # Split data into test and training
 
-train_data = data.passengers[:-12].to_numpy().reshape(-1,1)
-valid_data = data.passengers[-12:].to_numpy().reshape(-1,1)
+train_data_airlines = data_airlines.value[:-12]
+valid_data_airlines = data_airlines.value[-12:]
+
+##### SALINITY TIMESERIES, one site #####
+
+df_all = pd.read_csv('../2_process/out/conus_q_sc_airtemp.csv', 
+                     parse_dates=True,
+                     dtype={'site_no': str})
+
+df_site = df_all.query("site_no == '01104430'").dropna()
+df_site['value'] = df_site.spec_cond
+data_salt = df_site.drop(columns=['site_no', 'dateTime', 'discharge', 'airtemp', 'spec_cond'])
+
+# Visualize this data
+plt.figure(figsize=[12., 5.])
+plt.plot(data_salt.index, data_salt.value, 'b--', label='Spec cond', )
+
+# Splitting data!
+from sklearn.model_selection import train_test_split
+train_data_salt, valid_data_salt = train_test_split(data_salt, 
+                                                    train_size = 0.75,
+                                                    test_size = 0.25,
+                                                    random_state = 19)
+
+
+##### Change which dataset will be used #####
+
+# Flights example
+#data = data_airlines
+#train_data_df = train_data_airlines
+#valid_data_df = valid_data_airlines
+
+# Salinity example
+data = data_salt
+train_data_df = train_data_salt
+valid_data_df = valid_data_salt
+
+##### SHARED LSTM CODE #####
+
+train_data = train_data_df.to_numpy().reshape(-1,1)
+valid_data = valid_data_df.to_numpy().reshape(-1,1)
 
 # Scale/transform data
 t_scaler = MinMaxScaler(feature_range=(-1, 1))
@@ -54,10 +107,11 @@ lstm_model = salinity_lstm.salinityLSTM(input_size, hidden_size, num_layers, out
 
 ##### Train the model #####
 
-num_epochs = 500
+num_epochs = 50
 learning_rate = 0.0005
+print_rate = 10
 
-salinity_lstm.train(lstm_model, num_epochs, train_data, valid_data, lr=learning_rate)
+salinity_lstm.train(lstm_model, num_epochs, train_data, valid_data, lr=learning_rate, print_every=print_rate)
 
 ##### Generate predictions using the trained model #####
 
@@ -66,17 +120,17 @@ hs = None
 # Get predictions on training data
 train_preds, hs = lstm_model(train_data.unsqueeze(0), hs)
 train_preds = t_scaler.inverse_transform(train_preds.detach())
-train_time = data.index[1:-11]
+train_time = train_data_df.index
 
 # Get predictions on validation data
 valid_preds, hs = lstm_model(valid_x.unsqueeze(0), hs)
 valid_preds = v_scaler.inverse_transform(valid_preds.detach())
-valid_time = data.index[-11:]
+valid_time = valid_data_df.index
 
 ##### Plot predictions and actual data #####
 
-plt.plot(train_time, train_preds.squeeze(), 'r--', label='Training Predictions', )
+plt.plot(train_time, train_preds, 'r--', label='Training Predictions', )
 plt.plot(valid_time, valid_preds.squeeze(), 'g--', label='Validation Predictions')
-plt.plot(data.index, data.passengers.to_numpy(), label='Actual')
+plt.plot(data.index, data.value.to_numpy(), label='Actual')
 plt.xticks(np.arange(0,145,12))
 plt.legend()

--- a/lstm_modeling/salinity_lstm.py
+++ b/lstm_modeling/salinity_lstm.py
@@ -7,7 +7,6 @@
 
 from torch import nn, optim
 import numpy as np
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 class salinityLSTM(nn.Module):


### PR DESCRIPTION
This PR includes edits to the flight example dataset in order to use it to test having a categorical variable (`airline` was added and I am going to play with getting that to work as a quick test for multiple sites). It also includes the addition of salinity data from this pipeline and code changes to make it easy to flip back and forth between the two datasets (just comment/uncomment the code under the heading `Change which dataset will be used`). 

The results of these changes produce a logical/working LSTM salinity model for a single site using: 

- only specific conductivity (no other "features")
- randomly split train/valid
- 100 hidden layers
- 1 layer
- 20 epochs
- learning rate of 0.0005

Here are the resulting predictions:
![image](https://user-images.githubusercontent.com/13220910/211858730-96a36dfe-e05f-441f-b70f-69215576cc1c.png)
