### PR TITLE
Multi site test with salinity data

### DIFF
--- a/lstm_modeling/run_salinity_multicol_lstm.py
+++ b/lstm_modeling/run_salinity_multicol_lstm.py
@@ -63,21 +63,21 @@ plt.legend()
 # Scale/transform columns
 
 # Define the scaling fxns
-value_scaler_train_sites = MinMaxScaler(feature_range=(-1, 1))
-value_scaler_valid_sites = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_train_site1 = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_valid_site1 = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_train_site2 = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_valid_site2 = MinMaxScaler(feature_range=(-1, 1))
 
 # Then scale the data (use the same scalar for American and Delta)
-train_df_sites['01104430'] = value_scaler_train_sites.fit_transform(train_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
-valid_df_sites['01104430'] = value_scaler_valid_sites.fit_transform(valid_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
-train_df_sites['01104480'] = value_scaler_train_sites.fit_transform(train_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
-valid_df_sites['01104480'] = value_scaler_valid_sites.fit_transform(valid_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
+train_df_sites['01104430'] = value_scaler_train_site1.fit_transform(train_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites['01104430'] = value_scaler_valid_site1.fit_transform(valid_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
+train_df_sites['01104480'] = value_scaler_train_site2.fit_transform(train_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites['01104480'] = value_scaler_valid_site2.fit_transform(valid_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
 
 # Set more generic names used further below
 data = df_sites
 train_data_df = train_df_sites
 valid_data_df = valid_df_sites
-value_scaler_train = value_scaler_train_sites
-value_scaler_valid = value_scaler_valid_sites
 vloc = [data.columns.get_loc('01104430'), data.columns.get_loc('01104480')]
 
 # Convert to a tensor
@@ -117,9 +117,9 @@ hs = None
 
 train_preds, hs = lstm_model(train_data.unsqueeze(0), hs)
 train_preds_site1 = train_preds[:,vloc[0]].reshape(-1,1)
-train_preds_site1 = value_scaler_train.inverse_transform(train_preds_site1.detach())
+train_preds_site1 = value_scaler_train_site1.inverse_transform(train_preds_site1.detach())
 train_preds_site2 = train_preds[:,vloc[1]].reshape(-1,1)
-train_preds_site2 = value_scaler_train.inverse_transform(train_preds_site2.detach())
+train_preds_site2 = value_scaler_train_site2.inverse_transform(train_preds_site2.detach())
 
 # Resetting to be able to use the regular index in plotting because
 # the dateTime column causes the second plot values to be squished for
@@ -130,9 +130,9 @@ train_out['preds_01104480'] = train_preds_site2
 
 valid_preds, hs = lstm_model(valid_x.unsqueeze(0), hs)
 valid_preds_site1 = valid_preds[:,vloc[0]].reshape(-1,1)
-valid_preds_site1 = value_scaler_valid.inverse_transform(valid_preds_site1.detach())
+valid_preds_site1 = value_scaler_valid_site1.inverse_transform(valid_preds_site1.detach())
 valid_preds_site2 = valid_preds[:,vloc[1]].reshape(-1,1)
-valid_preds_site2 = value_scaler_valid.inverse_transform(valid_preds_site2.detach())
+valid_preds_site2 = value_scaler_valid_site2.inverse_transform(valid_preds_site2.detach())
 
 valid_out = valid_data_df.reset_index(inplace=False)[:-1]
 valid_out['preds_01104430'] = valid_preds_site1

--- a/lstm_modeling/run_salinity_multicol_lstm.py
+++ b/lstm_modeling/run_salinity_multicol_lstm.py
@@ -1,0 +1,159 @@
+# Script to train an LSTM using example data
+
+# References: 
+#     - https://github.com/wcneill/jn-ml-textbook/blob/master/Deep%20Learning/04%20Recurrent%20Networks/pytorch13b_LSTM.ipynb
+
+# Load appropriate libraries/modules
+import torch
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.preprocessing import MinMaxScaler
+import math
+
+# Load local functions
+import salinity_lstm
+
+##### Load and process the data #####
+
+percent_train = 0.75
+percent_valid = 0.25
+
+##### SALINITY TIMESERIES, two sites #####
+
+df_all = pd.read_csv('../2_process/out/conus_q_sc_airtemp.csv', 
+                     parse_dates=True,
+                     index_col = 'dateTime',
+                     dtype={'site_no': str})
+
+df_sites = df_all.query("site_no == ['01104430', '01104480']").dropna()
+df_sites['value'] = df_sites.spec_cond
+df_sites = df_sites.drop(columns=['spec_cond', 'discharge', 'airtemp'])
+# Note that the two site timeseries are different sizes
+
+# Visualize this data
+plt.figure(figsize=[12., 5.])
+plt.plot(df_sites.query("site_no == '01104430'").index, df_sites.query("site_no == '01104430'").value, 'b--', label='01104430', )
+plt.plot(df_sites.query("site_no == '01104480'").index, df_sites.query("site_no == '01104480'").value, 'r--', label='01104480', )
+plt.legend()
+
+# Try column for each site with value of interest as the column's values
+df_sites.reset_index(inplace=True)
+df_sites=df_sites.pivot(index = ['dateTime'], columns = 'site_no', values = 'value')
+df_sites = df_sites.dropna() # For now, drop the NAs (will need to learn how to split valid/train appropriately later)
+
+# Show another figure where the NAs are removed
+plt.figure(figsize=[12., 5.])
+plt.plot(df_sites.index, df_sites['01104430'], 'b--', label='01104430', )
+plt.plot(df_sites.index, df_sites['01104480'], 'r--', label='01104480', )
+plt.legend()
+
+# Split data into test and training
+n_train = math.ceil(len(df_sites)*percent_train)
+train_df_sites = df_sites[:n_train]
+valid_df_sites = df_sites[n_train:]
+
+plt.figure(figsize=[12., 5.])
+plt.plot(train_df_sites.index, train_df_sites['01104430'], 'blue', label='01104430, train', )
+plt.plot(valid_df_sites.index, valid_df_sites['01104430'], 'b--', label='01104430, valid', )
+plt.plot(train_df_sites.index, train_df_sites['01104480'], 'red', label='01104480, train', )
+plt.plot(valid_df_sites.index, valid_df_sites['01104480'], 'r--', label='01104480, valid', )
+plt.legend()
+
+# Scale/transform columns
+
+# Define the scaling fxns
+value_scaler_train_sites = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_valid_sites = MinMaxScaler(feature_range=(-1, 1))
+
+# Then scale the data (use the same scalar for American and Delta)
+train_df_sites['01104430'] = value_scaler_train_sites.fit_transform(train_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites['01104430'] = value_scaler_valid_sites.fit_transform(valid_df_sites['01104430'].to_numpy().reshape(-1,1)).reshape(-1)
+train_df_sites['01104480'] = value_scaler_train_sites.fit_transform(train_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites['01104480'] = value_scaler_valid_sites.fit_transform(valid_df_sites['01104480'].to_numpy().reshape(-1,1)).reshape(-1)
+
+# Set more generic names used further below
+data = df_sites
+train_data_df = train_df_sites
+valid_data_df = valid_df_sites
+value_scaler_train = value_scaler_train_sites
+value_scaler_valid = value_scaler_valid_sites
+vloc = [data.columns.get_loc('01104430'), data.columns.get_loc('01104480')]
+
+# Convert to a tensor
+train_data = torch.tensor(train_data_df.to_numpy(), dtype=torch.float32)
+valid_data = torch.tensor(valid_data_df.to_numpy(), dtype=torch.float32)
+
+# Create validation set (I don't really understand why there are separate
+# `valid_x` and `valid_y` that are shifted (so valid_x are all the values
+# except the last one and valid_y are all the values except the first one
+# which means that they both have one less value than the original valid data)
+valid_x = valid_data[:-1]
+valid_y = valid_data[1:]
+valid_data = (valid_x, valid_y)
+
+##### Define model and its parameters #####
+
+input_size = len(data.columns)
+hidden_size = 100
+num_layers = 1
+output_size = len(data.columns) # training the model fails when this is != input_size
+
+lstm_model = salinity_lstm.salinityLSTM(input_size, hidden_size, num_layers, output_size)
+
+##### Train the model #####
+
+num_epochs = 20
+learning_rate = 0.0005
+print_rate = 10
+
+salinity_lstm.train(lstm_model, num_epochs, train_data, valid_data, lr=learning_rate, print_every=print_rate)
+
+##### Generate predictions using the trained model #####
+
+hs = None
+
+# Get predictions on training data, then valid data
+
+train_preds, hs = lstm_model(train_data.unsqueeze(0), hs)
+train_preds_site1 = train_preds[:,vloc[0]].reshape(-1,1)
+train_preds_site1 = value_scaler_train.inverse_transform(train_preds_site1.detach())
+train_preds_site2 = train_preds[:,vloc[1]].reshape(-1,1)
+train_preds_site2 = value_scaler_train.inverse_transform(train_preds_site2.detach())
+
+# Resetting to be able to use the regular index in plotting because
+# the dateTime column causes the second plot values to be squished for
+# some reason.
+train_out = train_data_df.reset_index(inplace=False) 
+train_out['preds_01104430'] = train_preds_site1
+train_out['preds_01104480'] = train_preds_site2
+
+valid_preds, hs = lstm_model(valid_x.unsqueeze(0), hs)
+valid_preds_site1 = valid_preds[:,vloc[0]].reshape(-1,1)
+valid_preds_site1 = value_scaler_valid.inverse_transform(valid_preds_site1.detach())
+valid_preds_site2 = valid_preds[:,vloc[1]].reshape(-1,1)
+valid_preds_site2 = value_scaler_valid.inverse_transform(valid_preds_site2.detach())
+
+valid_out = valid_data_df.reset_index(inplace=False)[:-1]
+valid_out['preds_01104430'] = valid_preds_site1
+valid_out['preds_01104480'] = valid_preds_site2
+
+data_out = data.reset_index(inplace=False)
+
+# Adjust the valid time/index used to line up with the appropriate datetimes
+valid_time = data_out.index[(data_out['dateTime'] >= min(valid_out.dateTime)) & 
+                            (data_out['dateTime'] <= max(valid_out.dateTime))]
+
+##### Plot predictions and actual data #####
+
+fig, (ax1, ax2) = plt.subplots(2, figsize=[12., 5.])
+fig.suptitle('Predictions from one-value-column-per-site approach to a multi-site LSTM')
+ax1.plot(train_out.index, train_out.preds_01104430, 'r--', label='Training Predictions, 01104430', )
+ax1.plot(valid_time, valid_out.preds_01104430, 'g--', label='Validation Predictions, 01104430', )
+ax1.plot(data_out.index, data_out['01104430'].to_numpy(), label='Observations, 01104430', )
+ax2.plot(train_out.index, train_out.preds_01104480, 'r--', label='Training Predictions, 01104480', )
+ax2.plot(valid_time, valid_out.preds_01104480, 'g--', label='Validation Predictions, 01104480')
+ax2.plot(data_out.index, data_out['01104480'].to_numpy(), label='Observations, 01104480')
+plt.xticks(np.arange(0,145,12))
+ax1.legend()
+ax2.legend()

--- a/lstm_modeling/run_salinity_multiindex_lstm.py
+++ b/lstm_modeling/run_salinity_multiindex_lstm.py
@@ -1,0 +1,169 @@
+# Script to train an LSTM using example data
+
+# References: 
+#     - https://github.com/wcneill/jn-ml-textbook/blob/master/Deep%20Learning/04%20Recurrent%20Networks/pytorch13b_LSTM.ipynb
+
+# Load appropriate libraries/modules
+import torch
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.preprocessing import MinMaxScaler
+import math
+
+# Load local functions
+import salinity_lstm
+
+##### Load and process the data #####
+
+percent_train = 0.75
+percent_valid = 0.25
+
+##### SALINITY TIMESERIES, two sites #####
+
+df_all = pd.read_csv('../2_process/out/conus_q_sc_airtemp.csv', 
+                     parse_dates=True,
+                     index_col = 'dateTime',
+                     dtype={'site_no': str})
+
+df_sites = df_all.query("site_no == ['01104430', '01104480']").dropna()
+df_sites['value'] = df_sites.spec_cond
+df_sites = df_sites.drop(columns=['spec_cond', 'discharge', 'airtemp'])
+# Note that the two site timeseries are different sizes
+
+# Visualize this data
+plt.figure(figsize=[12., 5.])
+plt.plot(df_sites.query("site_no == '01104430'").index, df_sites.query("site_no == '01104430'").value, 'b--', label='01104430', )
+plt.plot(df_sites.query("site_no == '01104480'").index, df_sites.query("site_no == '01104480'").value, 'r--', label='01104480', )
+plt.legend()
+
+# Identify dateTimes and their indices prior to splitting into train/validate
+# so we can plot later
+df_time_site1 = df_sites.query("site_no == '01104430'").reset_index().dateTime
+df_time_site2 = df_sites.query("site_no == '01104480'").reset_index().dateTime
+
+# Try multi index rather than site as a feature
+df_sites.reset_index(inplace = True)
+df_sites = df_sites.set_index(['dateTime', 'site_no'])
+
+# Split data into test and training, ensuring both sites
+# end up in the training and validation sets
+n_all = len(df_sites)
+n_site1 = len(df_sites.reset_index(inplace=False).query("site_no == '01104430'").value)
+n_site2 = len(df_sites.reset_index(inplace=False).query("site_no == '01104480'").value)
+n_train_site1 = math.ceil(n_site1*percent_train)
+n_train_site2 = math.ceil(n_site2*percent_train)
+train_df_sites = pd.concat([df_sites[:n_train_site1], 
+                                df_sites[n_site1:(n_site1+n_train_site2)]])
+valid_df_sites = pd.concat([df_sites[n_train_site1:n_site1], 
+                                df_sites[(n_site1+n_train_site2):]])
+
+# Identify the dateTimes/indices of the valid and train splits, used in
+# plotting later.
+train_time_site1 = df_time_site1[:n_train_site1]
+train_time_site2 = df_time_site2[:n_train_site2]
+valid_time_site1 = df_time_site1[n_train_site1:]
+valid_time_site2 = df_time_site2[n_train_site2:]
+
+# Make a quick plot of the training and validation data
+# Reset index because we need the index val (without airline) for x-axis to plot
+train_df_sites_plot = train_df_sites.reset_index(inplace=False)
+valid_df_sites_plot = valid_df_sites.reset_index(inplace=False)
+plt.figure(figsize=[12., 5.])
+plt.plot(train_df_sites_plot.dateTime, train_df_sites_plot.value, 'b--', label='Train', )
+plt.plot(valid_df_sites_plot.dateTime, valid_df_sites_plot.value, 'g--', label='Valid', )
+plt.legend()
+
+# Scale/transform columns
+
+# Define the scaling fxns
+value_scaler_train_sites = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_valid_sites = MinMaxScaler(feature_range=(-1, 1))
+
+# Then scale the data (use the same scalar for American and Delta)
+train_df_sites.value = value_scaler_train_sites.fit_transform(train_df_sites.value.to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites.value = value_scaler_valid_sites.fit_transform(valid_df_sites.value.to_numpy().reshape(-1,1)).reshape(-1)
+
+# Set more generic names used further below
+data = df_sites
+train_data_df = train_df_sites
+valid_data_df = valid_df_sites
+value_scaler_train = value_scaler_train_sites
+value_scaler_valid = value_scaler_valid_sites
+vloc = data.columns.get_loc('value')
+
+# Convert to a tensor
+train_data = torch.tensor(train_data_df.to_numpy(), dtype=torch.float32)
+valid_data = torch.tensor(valid_data_df.to_numpy(), dtype=torch.float32)
+
+# Create validation set (I don't really understand why there are separate
+# `valid_x` and `valid_y` that are shifted (so valid_x are all the values
+# except the last one and valid_y are all the values except the first one
+# which means that they both have one less value than the original valid data)
+valid_x = valid_data[:-1]
+valid_y = valid_data[1:]
+valid_data = (valid_x, valid_y)
+
+##### Define model and its parameters #####
+
+input_size = len(data.columns)
+hidden_size = 100
+num_layers = 1
+output_size = len(data.columns) # training the model fails when this is != input_size
+
+lstm_model = salinity_lstm.salinityLSTM(input_size, hidden_size, num_layers, output_size)
+
+##### Train the model #####
+
+num_epochs = 20
+learning_rate = 0.0005
+print_rate = 10
+
+salinity_lstm.train(lstm_model, num_epochs, train_data, valid_data, lr=learning_rate, print_every=print_rate)
+
+##### Generate predictions using the trained model #####
+
+hs = None
+
+# Get predictions on training data, then valid data
+
+train_preds, hs = lstm_model(train_data.unsqueeze(0), hs)
+train_preds = train_preds[:,vloc].reshape(-1,1)
+train_preds = value_scaler_train.inverse_transform(train_preds.detach())
+
+valid_preds, hs = lstm_model(valid_x.unsqueeze(0), hs)
+valid_preds = valid_preds[:,vloc].reshape(-1,1)
+valid_preds = value_scaler_valid.inverse_transform(valid_preds.detach())
+
+# Separate by site
+train_data_out = train_df_sites_plot
+train_data_out['preds'] = train_preds
+train_preds_site1 = train_data_out.query("site_no == '01104430'")
+train_preds_site2 = train_data_out.query("site_no == '01104480'")
+
+valid_data_out = valid_df_sites_plot[:-1]
+valid_data_out['preds'] = valid_preds
+valid_preds_site1 = valid_data_out.query("site_no == '01104430'")
+valid_preds_site2 = valid_data_out.query("site_no == '01104480'")
+
+data_out = data.reset_index(inplace=False)
+data_out_site1 = data_out.query("site_no == '01104430'")
+data_out_site2 = data_out.query("site_no == '01104480'")
+
+##### Plot predictions and actual data #####
+
+custom_xlim = (min(data_out.index), max([max(df_time_site1.index), max(df_time_site2.index)]))
+
+fig, (ax1, ax2) = plt.subplots(2, figsize=[12., 5.])
+fig.suptitle('Predictions from MultiIndex approach to a multi-site LSTM')
+plt.setp(ax1, xlim=custom_xlim)
+plt.setp(ax2, xlim=custom_xlim)
+ax1.plot(train_time_site1.index, train_preds_site1.preds, 'r--', label='Training Predictions, 01104430', )
+ax2.plot(train_time_site2.index, train_preds_site2.preds, 'r--', label='Training Predictions, 01104480', )
+ax1.plot(valid_time_site1.index, valid_preds_site1.preds, 'g--', label='Validation Predictions, 01104430', )
+ax2.plot(valid_time_site2[:-1].index, valid_preds_site2.preds, 'g--', label='Validation Predictions, 01104480', )
+ax1.plot(df_time_site1.index, data_out_site1.value, label='Observations, 01104430')
+ax2.plot(df_time_site2.index, data_out_site2.value, label='Observations, 01104480')
+plt.xticks(np.arange(0,145,12))
+ax1.legend()
+ax2.legend()

--- a/lstm_modeling/run_salinity_onehot_lstm.py
+++ b/lstm_modeling/run_salinity_onehot_lstm.py
@@ -1,0 +1,170 @@
+
+# Script to train an LSTM using example data
+# Trying the one-hot encoding approach for different sites
+
+# References: 
+#     - https://github.com/wcneill/jn-ml-textbook/blob/master/Deep%20Learning/04%20Recurrent%20Networks/pytorch13b_LSTM.ipynb
+
+# Load appropriate libraries/modules
+import torch
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.preprocessing import MinMaxScaler
+import math
+
+# Load local functions
+import salinity_lstm
+
+##### Load and process the data #####
+
+percent_train = 0.75
+percent_valid = 0.25
+
+##### SALINITY TIMESERIES, two sites #####
+
+df_all = pd.read_csv('../2_process/out/conus_q_sc_airtemp.csv', 
+                     parse_dates=True,
+                     index_col = 'dateTime',
+                     dtype={'site_no': str})
+
+df_sites = df_all.query("site_no == ['01104430', '01104480']").dropna()
+df_sites['value'] = df_sites.spec_cond
+df_sites = df_sites.drop(columns=['spec_cond', 'discharge', 'airtemp'])
+# Note that the two site timeseries are different sizes
+
+# Visualize this data
+plt.figure(figsize=[12., 5.])
+plt.plot(df_sites.query("site_no == '01104430'").index, df_sites.query("site_no == '01104430'").value, 'b--', label='01104430', )
+plt.plot(df_sites.query("site_no == '01104480'").index, df_sites.query("site_no == '01104480'").value, 'r--', label='01104480', )
+plt.legend()
+
+# Try one-hot encoding for site
+df_sites = salinity_lstm.onehot_encode_pd(df_sites, 'site_no')
+
+# Identify dateTimes and their indices prior to splitting into train/validate
+# so we can plot later
+df_time_site1 = df_sites.query("site_no_01104430 == 1").reset_index().dateTime
+df_time_site2 = df_sites.query("site_no_01104480 == 1").reset_index().dateTime
+
+# Split data into test and training, ensuring both sites
+# end up in the training and validation sets
+n_all = len(df_sites)
+n_site1 = len(df_sites.reset_index(inplace=False).query("site_no_01104430 == 1").value)
+n_site2 = len(df_sites.reset_index(inplace=False).query("site_no_01104480 == 1").value)
+n_train_site1 = math.ceil(n_site1*percent_train)
+n_train_site2 = math.ceil(n_site2*percent_train)
+
+train_df_site1 = df_sites.query('site_no_01104430 == 1')[:n_train_site1]
+train_df_site2 = df_sites.query('site_no_01104480 == 1')[:n_train_site2]
+valid_df_site1 = df_sites.query('site_no_01104430 == 1')[n_train_site1:]
+valid_df_site2 = df_sites.query('site_no_01104480 == 1')[n_train_site2:]
+
+train_df_sites = pd.concat([train_df_site1, train_df_site2])
+valid_df_sites = pd.concat([valid_df_site1, valid_df_site2])
+
+plt.figure(figsize=[12., 5.])
+plt.plot(train_df_site1.index, train_df_site1.value, 'blue', label='01104430, train', )
+plt.plot(valid_df_site1.index, valid_df_site1.value, 'b--', label='01104430, valid', )
+plt.plot(train_df_site2.index, train_df_site2.value, 'red', label='01104480, train', )
+plt.plot(valid_df_site2.index, valid_df_site2.value, 'r--', label='01104480, valid', )
+plt.legend()
+
+# Identify the dateTimes/indices of the valid and train splits, used in
+# plotting later.
+train_time_site1 = df_time_site1[:n_train_site1]
+train_time_site2 = df_time_site2[:n_train_site2]
+valid_time_site1 = df_time_site1[n_train_site1:]
+valid_time_site2 = df_time_site2[n_train_site2:]
+
+# Scale/transform columns
+
+# Define the scaling fxns
+value_scaler_train = MinMaxScaler(feature_range=(-1, 1))
+value_scaler_valid = MinMaxScaler(feature_range=(-1, 1))
+
+# Then scale the data (use the same scalar for American and Delta)
+train_df_sites.value = value_scaler_train.fit_transform(train_df_sites.value.to_numpy().reshape(-1,1)).reshape(-1)
+valid_df_sites.value = value_scaler_valid.fit_transform(valid_df_sites.value.to_numpy().reshape(-1,1)).reshape(-1)
+
+# Set more generic names used further below
+data = df_sites
+train_data_df = train_df_sites
+valid_data_df = valid_df_sites
+vloc = data.columns.get_loc('value')
+
+# Convert to a tensor
+train_data = torch.tensor(train_data_df.to_numpy(), dtype=torch.float32)
+valid_data = torch.tensor(valid_data_df.to_numpy(), dtype=torch.float32)
+
+# Create validation set (I don't really understand why there are separate
+# `valid_x` and `valid_y` that are shifted (so valid_x are all the values
+# except the last one and valid_y are all the values except the first one
+# which means that they both have one less value than the original valid data)
+valid_x = valid_data[:-1]
+valid_y = valid_data[1:]
+valid_data = (valid_x, valid_y)
+
+##### Define model and its parameters #####
+
+input_size = len(data.columns)
+hidden_size = 100
+num_layers = 1
+output_size = len(data.columns) # training the model fails when this is != input_size
+
+lstm_model = salinity_lstm.salinityLSTM(input_size, hidden_size, num_layers, output_size)
+
+##### Train the model #####
+
+num_epochs = 20
+learning_rate = 0.0005
+print_rate = 10
+
+salinity_lstm.train(lstm_model, num_epochs, train_data, valid_data, lr=learning_rate, print_every=print_rate)
+
+##### Generate predictions using the trained model #####
+
+hs = None
+
+# Get predictions on training data, then valid data
+
+train_preds, hs = lstm_model(train_data.unsqueeze(0), hs)
+train_preds = train_preds[:,vloc].reshape(-1,1)
+train_preds = value_scaler_train.inverse_transform(train_preds.detach())
+
+valid_preds, hs = lstm_model(valid_x.unsqueeze(0), hs)
+valid_preds = valid_preds[:,vloc].reshape(-1,1)
+valid_preds = value_scaler_valid.inverse_transform(valid_preds.detach())
+
+# Separate by site
+train_data_out = train_df_sites
+train_data_out['preds'] = train_preds
+train_preds_site1 = train_data_out.query('site_no_01104430 == 1')
+train_preds_site2 = train_data_out.query('site_no_01104480 == 1')
+
+valid_data_out = valid_df_sites[:-1]
+valid_data_out['preds'] = valid_preds
+valid_preds_site1 = valid_data_out.query('site_no_01104430 == 1')
+valid_preds_site2 = valid_data_out.query('site_no_01104480 == 1')
+
+data_out = data.reset_index()
+data_out_site1 = data_out.query('site_no_01104430 == 1')
+data_out_site2 = data_out.query('site_no_01104480 == 1')
+
+##### Plot predictions and actual data #####
+
+custom_xlim = (min(data_out.index), max([max(df_time_site1.index), max(df_time_site2.index)]))
+
+fig, (ax1, ax2) = plt.subplots(2, figsize=[12., 5.])
+fig.suptitle('Predictions from one-hot encoding approach to a multi-site LSTM')
+plt.setp(ax1, xlim=custom_xlim)
+plt.setp(ax2, xlim=custom_xlim)
+ax1.plot(train_time_site1.index, train_preds_site1.preds, 'r--', label='Training Predictions, site1', )
+ax2.plot(train_time_site2.index, train_preds_site2.preds, 'r--', label='Training Predictions, site2', )
+ax1.plot(valid_time_site1.index, valid_preds_site1.preds, 'g--', label='Validation Predictions, site1', )
+ax2.plot(valid_time_site2[:-1].index, valid_preds_site2.preds, 'g--', label='Validation Predictions, site2', )
+ax1.plot(df_time_site1.index, data_out_site1.value, label='Observations, site1')
+ax2.plot(df_time_site2.index, data_out_site2.value, label='Observations, site2')
+plt.xticks(np.arange(0,145,12))
+ax1.legend()
+ax2.legend()


### PR DESCRIPTION
Trying out lessons learned from #7 to the salinity data. Keeping each approach in a separate `.py` for now so that it is easy to re-run each during testing.

- **_Approach 1: Move the value we are trying to predict into its own column for each "site"._** In this approach, I created a column called `01104430` and `01104480`, whose values are the specific conductivity values. I then build the LSTM with these two columns as features (with no other features) and then extracted them at the end.
- **_Approach 2: Apply a one-hot encoder to the site data._** This approach is similar to the last, except that there is still a `value` column representing the values I would like to predict and the sites are added as their own column (`01104430` and `01104430`) which contain 0s or 1s for which airline each row of data represents. I got this idea from reading [this blog Kaan Kuguoglu](https://towardsdatascience.com/building-rnn-lstm-and-gru-for-time-series-using-pytorch-a46e5b094e7b).
- **_Approach 3: Include site as part of a MultIindex_**: In this approach, the airline type is moved from being a column to being part of the data index (which is where the time component goes to maintain ordering). This is easily done with `df.set_index()` and then reset with `df.reset_index()` in order to make plots.

## Results

Visually the MultiIndex (`Approach 3`) seems to be the best. I'll need to look into methods for extracting numerical values to evaluate and compare soon.

The two sites data that are being fit:

![image](https://user-images.githubusercontent.com/13220910/212199929-838d8a9d-bd2c-4525-8fee-30de6085fa58.png)

### Approach 1: move the value we are trying to predict into its own column for each "site" and treat as features

For this approach, I removed any rows with NAs. This meant that I truncated the Site 1 data to be the same length as the Site 2 data. I think you could get around that somehow, but just something to know when you are looking at the plots.

![image](https://user-images.githubusercontent.com/13220910/212152393-4bce3f79-786a-463e-8500-8cd0c1a11940.png)

## Approach 2: one-hot encode the site information as feature columns

![image](https://user-images.githubusercontent.com/13220910/212202033-56b21667-b382-461c-b76a-5039a47868e8.png)

## Approach 3: include site as part of a MultIindex

![image](https://user-images.githubusercontent.com/13220910/212202569-090f5ed3-1997-42b3-99f8-1b2f7b9c0e1b.png)
