### PR TITLE
Download watersheds

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -278,6 +278,13 @@ p1_targets <- list(
     nhd_comid_xwalk <- bind_cols(q_sc_site_df, nhd_info)
     
     return(nhd_comid_xwalk)
-  })
+  }),
+  
+  tar_target(nhd_huc04_site_xwalk, 
+             q_sc_nhd_comid %>%
+               mutate(HUC04 = substr(REACHCODE, 1, 4)) %>% 
+               select(site_no, HUC04)),
+  tar_target(nhd_huc04s, unique(nhd_huc04_site_xwalk$HUC04)),
+  tar_target(nhd_huc04s_sf, get_huc(id = nhd_huc04s, type = "huc04"))
   
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -258,7 +258,8 @@ p1_targets <- list(
   
   tar_target(q_sc_nhd_comid, {
     sf::sf_use_s2(FALSE)
-    q_sc_sites_sf %>%
+    # Fetch NHD COMIDs for each site
+    nhd_info <- q_sc_sites_sf %>%
       mutate(row_num = row_number()) %>%
       split(.$site_no) %>%
       purrr::map(~{
@@ -267,9 +268,16 @@ p1_targets <- list(
           message('Starting flow index for ', .x$row_num, ' out of ', nrow(q_sc_sites_sf))
         }
         suppressMessages(get_flowline_index(.x, flines = "download_nhdplusv2"))
-      }) %>%
-      bind_rows() %>%
+      }) %>% bind_rows() %>%
       select(COMID, REACHCODE, REACH_meas)
+    
+    # Immediately bind site numbers to their corresponding COMIDs
+    q_sc_site_df <- q_sc_sites_sf %>% 
+      st_drop_geometry() %>% 
+      select(site_no)
+    nhd_comid_xwalk <- bind_cols(q_sc_site_df, nhd_info)
+    
+    return(nhd_comid_xwalk)
   })
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -62,10 +62,8 @@ p2_targets <- list(
                left_join(distinct(conus_q_data), by = c("state_abbr", "site_no", "dateTime")) %>% 
                filter(!is.na(mean_spec_cond), !is.na(mean_q))),
   
-  tar_target(q_sc_site_comid_xwalk, bind_cols(q_sc_sites_sf, q_sc_nhd_comid)),
-  
   # Join the transmissivity and depth-to-watertable data by COMID
-  tar_target(q_sc_sites_info, q_sc_site_comid_xwalk %>% 
+  tar_target(q_sc_sites_info, q_sc_nhd_comid %>% 
                filter(site_no %in% unique(q_sc_sites_sf$site_no)) %>% 
                left_join(trans, by="COMID") %>% 
                left_join(dtw, by="COMID") %>% 

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -73,6 +73,32 @@ p3_targets <- list(
                                                          lm_plots_ls[[2]], ma_plots_ls[[2]], nrow = 2)),
   tar_target(trend_plots_compare_3_4, cowplot::plot_grid(lm_plots_ls[[3]], ma_plots_ls[[3]],
                                                          lm_plots_ls[[4]], ma_plots_ls[[4]], nrow = 2)),
-  tar_target(trend_plots_compare_5, cowplot::plot_grid(lm_plots_ls[[5]], ma_plots_ls[[5]], nrow = 1))
+  tar_target(trend_plots_compare_5, cowplot::plot_grid(lm_plots_ls[[5]], ma_plots_ls[[5]], nrow = 1)),
+  
+  # Plot HUCs and sites
+  tar_target(map_sites_huc04s, {
+    sites_sf <- st_transform(q_sc_sites_sf, usmap_crs())
+    huc04s_sf <- st_transform(nhd_huc04s_sf, usmap_crs())
+    
+    # States with salt application rates data 
+    conus_salt_sf <- usmap::us_map(exclude = c(states_to_exclude, "AK", "HI")) %>% 
+      st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
+      group_by(group, abbr) %>% 
+      summarise(geometry = st_combine(geometry), .groups="keep") %>%
+      st_cast("POLYGON")
+    # States without salt application rates data 
+    conus_nosalt_sf <- usmap::us_map(include = states_to_exclude) %>% 
+      st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
+      group_by(group, abbr) %>% 
+      summarise(geometry = st_combine(geometry), .groups="keep") %>%
+      st_cast("POLYGON")
+    
+    ggplot() +
+      geom_sf(data=conus_nosalt_sf, fill='#b8b8b8', color=NA) +
+      geom_sf(data=conus_salt_sf, fill='#f4f4f4', color='#898989') +
+      geom_sf(data=huc04s_sf, fill='#daeaf3', color='#38799f', size=3, alpha = 0.65) +
+      geom_sf(data=sites_sf, color='#d08b2c', shape=17) +
+      theme_void()
+  })
   
 )

--- a/_targets.R
+++ b/_targets.R
@@ -13,7 +13,8 @@ tar_option_set(packages = c(
   'sbtools',
   'scico',
   'sf',
-  'tidyverse'
+  'tidyverse',
+  'usmap'
 ))
 
 start_date <- '2010-01-01'


### PR DESCRIPTION
Addressing part of #10. Added HUC04 watersheds fetch based on the available REACHCODE values from a previous target. Also, included a target that maps the states, HUC04s, and sites. It would be easy to switch to HUC 08 or HUC 12 if I wanted smaller watersheds.

Running `tar_read(map_sites_huc04s)` gives you this map:

![image](https://user-images.githubusercontent.com/13220910/228089628-240d9ba1-cb65-4d49-93aa-2cfa952a03c5.png)
