### PR TITLE
Download roadsalt

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -245,6 +245,23 @@ p1_targets <- list(
   tar_target(dtw, read_csv(dtw_csv, col_types = cols()) %>% 
                select(COMID = comid, dtw_MEAN = MEAN, dtw250, totdtw250)),
   
+  ##### Download road salt data #####
+  
+  tar_target(road_salt_all_zip, format="file", 
+             item_file_download(sb_id = '5b15a50ce4b092d9651e22b9',
+                                names = '1992_2015.zip',
+                                destinations = '1_fetch/out/road_salt_all.zip')),
+  # Extract only the 2015 data
+  tar_target(road_salt_2015_tif, {
+    file_out <- '1_fetch/out/road_salt_2015.tif'
+    file_extracted <- '1_fetch/out/2015.tif'
+    zip::unzip(zipfile = road_salt_all_zip,
+               files = basename(file_extracted),
+               exdir = dirname(file_extracted))
+    file.rename(from = file_extracted, to = file_out)
+    return(file_out)
+  }, format = 'file'),
+  
   ##### Download NHD Data #####
   
   # Identify the sites & find their matching COMIDs

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -302,6 +302,24 @@ p1_targets <- list(
                mutate(HUC04 = substr(REACHCODE, 1, 4)) %>% 
                select(site_no, HUC04)),
   tar_target(nhd_huc04s, unique(nhd_huc04_site_xwalk$HUC04)),
-  tar_target(nhd_huc04s_sf, get_huc(id = nhd_huc04s, type = "huc04"))
+  tar_target(nhd_huc04s_sf, get_huc(id = nhd_huc04s, type = "huc04")),
+  
+  ##### Get US sf objects for plotting #####
+  
+  # States with salt application rates data
+  tar_target(conus_salt_sf, 
+             usmap::us_map(exclude = c(states_to_exclude, "AK", "HI")) %>% 
+               st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
+               group_by(group, abbr) %>% 
+               summarise(geometry = st_combine(geometry), .groups="keep") %>%
+               st_cast("POLYGON")),
+  
+  # States without salt application rates data 
+  tar_target(conus_nosalt_sf, 
+             usmap::us_map(include = states_to_exclude) %>% 
+               st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
+               group_by(group, abbr) %>% 
+               summarise(geometry = st_combine(geometry), .groups="keep") %>%
+               st_cast("POLYGON"))
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -50,7 +50,34 @@ p2_targets <- list(
     return(file_out)
   }, format = 'file'),
   
-  ##### Process sites data for trend exploration #####
+  ##### Process sites data for groundwater trend exploration #####
+  
+  # Load and reproject road salt raster data
+  tar_target(road_salt_2015_raster, {
+    r <- raster(road_salt_2015_tif)
+    rtransf <- projectRaster(r, crs = st_crs(nhd_huc04s_sf)$proj4string)
+    return(rtransf)
+  }),
+  
+  # For each HUC, crop the raster to the polygon
+  tar_target(nhd_hucs, nhd_huc04s_sf$huc4),
+  tar_target(road_salt_2015_raster_huc_list, {
+    # Mask the CONUS raster to each HUC
+    huc04_mask <- filter(nhd_huc04s_sf, huc4 == nhd_hucs)
+    huc04_salt_raster <- mask(road_salt_2015_raster, huc04_mask)
+    list(huc04 = nhd_hucs, road_salt_raster = huc04_salt_raster)
+  }, pattern = map(nhd_hucs), iteration='list'),
+  
+  # Summarize each HUC's raster into a tibble
+  tar_target(road_salt_2015_huc_summary, {
+    huc_r <- road_salt_2015_raster_huc_list$road_salt_raster
+    tibble(HUC04 = road_salt_2015_raster_huc_list$huc04,
+           salt_min = cellStats(huc_r, stat='min', na.rm=TRUE),
+           salt_p25 = unname(quantile(huc_r, probs=0.25, na.rm=TRUE)),
+           salt_mean = cellStats(huc_r, stat='mean', na.rm=TRUE),
+           salt_p75 = unname(quantile(huc_r, probs=0.75, na.rm=TRUE)),
+           salt_max = cellStats(huc_r, stat='max', na.rm=TRUE))
+  }, pattern = map(road_salt_2015_raster_huc_list)),
   
   # Add percentiles to be able to show relative transmissivity/dtw
   tar_target(trans_ecdf, ecdf(trans$trans_MEAN)),

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -80,19 +80,6 @@ p3_targets <- list(
     sites_sf <- st_transform(q_sc_sites_sf, usmap_crs())
     huc04s_sf <- st_transform(nhd_huc04s_sf, usmap_crs())
     
-    # States with salt application rates data 
-    conus_salt_sf <- usmap::us_map(exclude = c(states_to_exclude, "AK", "HI")) %>% 
-      st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
-      group_by(group, abbr) %>% 
-      summarise(geometry = st_combine(geometry), .groups="keep") %>%
-      st_cast("POLYGON")
-    # States without salt application rates data 
-    conus_nosalt_sf <- usmap::us_map(include = states_to_exclude) %>% 
-      st_as_sf(coords = c('x', 'y'), crs = usmap::usmap_crs()) %>% 
-      group_by(group, abbr) %>% 
-      summarise(geometry = st_combine(geometry), .groups="keep") %>%
-      st_cast("POLYGON")
-    
     ggplot() +
       geom_sf(data=conus_nosalt_sf, fill='#b8b8b8', color=NA) +
       geom_sf(data=conus_salt_sf, fill='#f4f4f4', color='#898989') +

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -86,6 +86,23 @@ p3_targets <- list(
       geom_sf(data=huc04s_sf, fill='#daeaf3', color='#38799f', size=3, alpha = 0.65) +
       geom_sf(data=sites_sf, color='#d08b2c', shape=17) +
       theme_void()
+  }),
+  
+  # Map road salt info per HUC
+  tar_target(map_huc04s_roadsalt, {
+    
+    huc04s_sf <- st_transform(nhd_huc04s_sf, usmap_crs()) %>% 
+      left_join(road_salt_2015_huc_summary, by = c('huc4' = 'HUC04')) %>% 
+      pivot_longer(cols = starts_with('salt_'), names_to = 'salt_var') %>% 
+      mutate(salt_var = gsub('salt_', '', salt_var))
+    
+    ggplot() +
+      geom_sf(data=conus_nosalt_sf, fill='#b8b8b8', color=NA) +
+      geom_sf(data=conus_salt_sf, fill='#f4f4f4', color='#898989') +
+      geom_sf(data=huc04s_sf, aes(fill=value), color='black') +
+      scale_fill_scico(palette = 'davos', name = 'Salt applied in 2015 (lbs)') +
+      theme_void() + 
+      facet_wrap(vars(salt_var), ncol = 2)
   })
   
 )

--- a/_targets.R
+++ b/_targets.R
@@ -10,6 +10,7 @@ tar_option_set(packages = c(
   'lubridate',
   'maps',
   'nhdplusTools',
+  'raster',
   'sbtools',
   'scico',
   'sf',


### PR DESCRIPTION
Addresses part of #10. Download and summarize 2015 road salt raster data ([Bock et al., 2018](https://www.sciencebase.gov/catalog/item/5b15a50ce4b092d9651e22b9)) per HUC 04. Includes a map of maximum road salt application values per HUC. Originally had multiple summary stats plotted but only the maximum was interesting (both map versions are shown below).

![image](https://user-images.githubusercontent.com/13220910/228349044-9c132779-d12d-466d-bb95-29ffb50b5e7f.png)

![image](https://user-images.githubusercontent.com/13220910/228346039-29df1c71-ae85-4aca-8e26-610a17fc57e5.png)

May want to consider smaller HUCs (like HUC 8s?) to capture more variability of application rates.

```r
library(raster)
library(targets)
r <- tar_read(road_salt_2015_raster_huc_list)[[15]][['road_salt_raster']]
plot(r)
```

![image](https://user-images.githubusercontent.com/13220910/228346826-1556d2c5-79c0-4fdc-a01e-3efcc6968e5a.png)
