### PR TITLE
apply Mann-Kendall to each of the trend tests & visualizations

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -136,6 +136,7 @@ p2_targets <- list(
                mutate(SC_flow_normalized = SpecCond / (Q+0.000000001))),
   
   tar_target(sc_trend_data_lm, add_trends(q_sc_data_baseq, trend_method = "LM")),
-  tar_target(sc_trend_data_ma, add_trends(q_sc_data_baseq, trend_method = "MA"))
-  
+  tar_target(sc_trend_data_ma, add_trends(q_sc_data_baseq, trend_method = "MA")),
+  tar_target(sc_trend_data_mk, add_trends(q_sc_data_baseq, trend_method = "MK"))
+  # TODO: COME BACK TO THE NA ONES: sum(is.na(sc_trend_data_mk$trend)) --> 416
 )

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -68,6 +68,7 @@ p3_targets <- list(
   
   tar_target(lm_plots_ls, calc_and_plot_trend(sc_trend_data_lm, "LM", subtitle_caveat = "Dugan et al., 2017 salt states")),
   tar_target(ma_plots_ls, calc_and_plot_trend(sc_trend_data_ma, "MA", subtitle_caveat = "Dugan et al., 2017 salt states")),
+  tar_target(mk_plots_ls, calc_and_plot_trend(sc_trend_data_mk, "MK", subtitle_caveat = "Dugan et al., 2017 salt states")),
   
   tar_target(trend_plots_compare_1_2, cowplot::plot_grid(lm_plots_ls[[1]], ma_plots_ls[[1]], 
                                                          lm_plots_ls[[2]], ma_plots_ls[[2]], nrow = 2)),

--- a/_targets.R
+++ b/_targets.R
@@ -7,6 +7,7 @@ tar_option_set(packages = c(
   'dataRetrieval',
   'geofacet',
   'grwat', # devtools::install_github('tsamsonov/grwat')
+  'Kendall',
   'lubridate',
   'maps',
   'nhdplusTools',


### PR DESCRIPTION
Addresses part of #10. This Mann-Kendall could definitely use more refinement, but is good for now. Includes use of p-values to only mark a trend as `positive` or `negative` if it was statistically significant. Otherwise, `zero`. There's an issue with some trends that are returning `NA` with an "error" that doesn't actually cause the code to stop. Will return to those at a later date.