### PR TITLE
Add SC trends and cleanup time series

### DIFF
--- a/1_Download/src/nwis_fxns.R
+++ b/1_Download/src/nwis_fxns.R
@@ -92,6 +92,7 @@ inventory_nwis_data <- function(site_numbers, param_cd, start_date, end_date) {
     left_join(data_info, by = c('site_no', query_service = 'data_type_cd', 'stat_cd')) %>%  
     # Cleanup table to return
     select(site_no, query_service, 
+           datastream_name = loc_web_ds, # This is sometimes used to distinguish multiple sensors at one site
            begin_date, end_date, 
            days_count = count_nu, 
            year_span, year_coverage, 

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -96,7 +96,8 @@ p2_targets <- list(
   
   ###### ATTR DATA 3: Calculate SC trend per site ######
   
-  # TODO: Calculate SC trends to add as a static attribute
+  # Calculate SC trends to add as a static attribute
+  tar_target(p2_attr_sc_trends, calculate_sc_trend(p2_ts_sc_dv_feather, max_pval = 0.05)),
   
   ###### ATTR DATA 4: Pivot and link NHD+ attributes to sites ######
   
@@ -109,6 +110,7 @@ p2_targets <- list(
   
   tar_target(p2_attr_all, combine_static_attributes(p2_attr_meanFlow,
                                                     p2_attr_roadSalt,
+                                                    p2_attr_sc_trends,
                                                     p2_attr_nhd))
   
 )

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -60,10 +60,6 @@ p2_targets <- list(
   tar_target(p2_ts_sc_detrend_sites, identify_sites_to_detrend(p2_ts_sc_dv_gapFilled, 'SpecCond')),
   tar_target(p2_ts_sc_dv_detrend, detrend_ts_data(p2_ts_sc_dv_gapFilled, p2_ts_sc_detrend_sites, 'SpecCond')),
   
-  ###### TS DATA 5: Split SC timeseries into individual site-years ######
-  
-  # TODO: Split SC timeseries into site-years
-  
   ##### STATIC ATTRIBTUES PREP #####
   
   # All are prefixed with `p2_attr_`

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -3,6 +3,7 @@
 
 source('2_Prepare/src/ts_nwis_fxns.R')
 source('2_Prepare/src/ts_gap_fxns.R')
+source('2_Prepare/src/ts_detrend_fxns.R')
 source('2_Prepare/src/attr_prep_fxns.R')
 source('2_Prepare/src/attr_combine_all.R')
 
@@ -54,7 +55,10 @@ p2_targets <- list(
   
   ###### TS DATA 4: Detrend the SC timeseries ######
   
-  # TODO: Detrend the SC timeseries since we are using trend as a static attr
+  # Detrend the SC timeseries since we are using trend as a static attr
+  # Detrend only works for sites without any NAs in their time series
+  tar_target(p2_ts_sc_detrend_sites, identify_sites_to_detrend(p2_ts_sc_dv_gapFilled, 'SpecCond')),
+  tar_target(p2_ts_sc_dv_detrend, detrend_ts_data(p2_ts_sc_dv_gapFilled, p2_ts_sc_detrend_sites, 'SpecCond')),
   
   ###### TS DATA 5: Split SC timeseries into individual site-years ######
   

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -26,6 +26,7 @@ p2_targets <- list(
   
   ###### TS DATA 2: Combine all daily mean SC data ######
   
+  # Also, it replaces values of -999999. 
   tar_target(p2_ts_sc_dv_feather, 
              combine_all_dv_data(out_file = '2_Prepare/tmp/ts_sc_dv.feather',
                                  in_files = c(p2_ts_sc_uv_to_dv_feather,
@@ -36,8 +37,7 @@ p2_targets <- list(
   ###### TS DATA 3: Fill in missing SC values ######
   
   # TODO: Keep investigating WRTDS for gap-filling. For now, this is simple 
-  # linear interpolation for any gap of 5 or fewer days. Also, it replaces
-  # values of -999999. Do this per site!
+  # linear interpolation for any gap of 5 or fewer days. Do this per site!
   tar_target(p2_ts_sc_dv_bySite, 
              read_feather(p2_ts_sc_dv_feather) %>% 
                group_by(site_no) %>% 

--- a/2_Prepare/src/attr_prep_fxns.R
+++ b/2_Prepare/src/attr_prep_fxns.R
@@ -15,6 +15,178 @@ calculate_mean_q_per_site <- function(in_file) {
     summarize(attr_meanFlow = mean(Flow, na.rm = TRUE))
 }
 
+#' @title Calculate a trend in SC per site
+#' @description For each site in the data, apply different trend algorithms to 
+#' categorize that site's SC data as trending 'positive', 'negative', or 'none'.
+#' 
+#' @param in_file a character string indicating the file path containing all
+#' daily SC records with at least the columns `site_no`, `dateTime`, and `SpecCond`.
+#' @param max_pval numeric value indicating the maximum p-value that is allowed
+#' to declare a trend significant. Passed on to `extract_mk_trend()`. 
+#' 
+calculate_sc_trend <- function(in_file, max_pval = 0.05) {
+  # TODO: which of these trend tests should we use?
+  read_feather(in_file) %>% 
+    split(.$site_no) %>% 
+    map(~{tibble(
+      attr_TrendMannKendall = apply_MannKendall(.x, max_pval = 0.05),
+      attr_TrendMannKendall_DS = apply_MannKendall(.x, max_pval = 0.05, deseasonalize = TRUE),
+      attr_TrendSeasonalMK = apply_SeasonalMannKendall(.x, max_pval = 0.05)
+    )}) %>% 
+    bind_rows(.id = 'site_no')
+}
+
+#' @title Z-normalize a set of values
+#' @description Find the z-scores for a set of values. This assumes that the
+#' values passed in are already grouped appropriately prior to this function
+#' being used. Courtesy of https://jmotif.github.io/sax-vsm_site/morea/algorithm/znorm.html
+#' 
+#' @param ts a vector of numeric values
+#' 
+#' @return a vector the same length as `ts` but with z-scored values
+#' 
+znorm <- function(ts){
+  ts.mean <- mean(ts)
+  ts.dev <- sd(ts)
+  (ts - ts.mean)/ts.dev
+}
+
+#' @title Find a trend in SC using a Mann-Kendall test
+#' @description Calculate a trend for SC data using `Kendall::MannKendall()`
+#' 
+#' @param ts_data a tibble of SC timeseries data for a single site with at least
+#' the columns `dateTime` and `SpecCond`.
+#' @param max_pval numeric value indicating the maximum p-value that is
+#' allowed to declare a trend significant. Passed on to `extract_mk_trend()`
+#' @param deseasonalize logical flag indicating whether the data should be
+#' "desseasonalized" (aka z-scored) prior to a trend being calculated. TBD
+#' on whether this approach will remain. Defaults to FALSE.
+#' 
+#' @return a character string indicating the trend as "none", "positive", or "negative"
+#' 
+apply_MannKendall <- function(ts_data, max_pval, deseasonalize=FALSE) {
+  
+  # Note that you do not need to fill in NAs for missing dates.
+  # It does not change the trend results for the `MannKendall()` function.
+  
+  # Convert the data into a `ts` object to pass to `MannKendall()`
+  if(deseasonalize) {
+    # TODO: should we "de-seasonalize"? (AKA z-score) to calculate 
+    # a trend when using MannKendall?
+    ts_data_ds <- ts_data %>% 
+      # TODO: Should it be done by day? By month?
+      mutate(doy = lubridate::yday(dateTime)) %>% 
+      group_by(doy) %>% 
+      mutate(SpecCond_ds = znorm(SpecCond)) %>% 
+      ungroup() %>% 
+      dplyr::select(-doy)
+    
+    min_date <- min(ts_data_ds$dateTime)
+    mk_data <- ts(ts_data_ds$SpecCond_ds, 
+                  start = c(lubridate::year(min_date), 
+                            lubridate::yday(min_date)), 
+                  frequency = 365)
+  } else {
+    min_date <- min(ts_data$dateTime)
+    mk_data <- ts(ts_data$SpecCond, 
+                  start = c(lubridate::year(min_date), 
+                            lubridate::yday(min_date)), 
+                  frequency = 365)
+  }
+  
+  # Run the Mann-Kendall model and extract the trend result
+  mk_data %>% 
+    Kendall::MannKendall() %>% 
+    extract_mk_trend(max_pval = max_pval)
+  
+}
+
+#' @title Find a trend in SC using a Seasonal Mann-Kendall test
+#' @description Calculate a trend for SC data using `Kendall::SeasonalMannKendall()`
+#' 
+#' @param ts_data a tibble of SC timeseries data for a single site with at least
+#' the columns `dateTime` and `SpecCond`.
+#' @param max_pval numeric value indicating the maximum p-value that is
+#' allowed to declare a trend significant. Passed on to `extract_mk_trend()`
+#' 
+#' @return a character string indicating the trend as "none", "positive", or "negative"
+#' 
+apply_SeasonalMannKendall <- function(ts_data, max_pval) {
+  
+  # According to PNNL: https://vsp.pnnl.gov/help/Vsample/Design_Trend_Seasonal_Kendall.htm
+  # Use seasonal MK when the "presence of seasonality implies that the data have different distributions for 
+  #   different seasons (e.g., months) of the year. For example, a monotonic upward trend may exist over years 
+  #   for January but not for June." AND a "monotonic upward (downward) trend means that the variable consistently 
+  #   increases (decreases) over time, but the trend may or may not be linear."
+  # Use MK when "seasonality is not expected to be present or when trends occur in different directions 
+  #   (up or down) in different seasons." If there is seasonality but trends might be in different directions,
+  #   looks like you might be able to "de-seasonalize" first?? See examples in `?Kendall::MannKendall`
+  # While I think that the trends may be different by season, I'm not sure we can apply the blanket statement 
+  # that they will all either be going up or down. I think there may be instances where winter seasons are going
+  # up but summer are going down?
+  
+  # To use a Seasonal Mann-Kendall, first transform the data into monthly averages
+  ts_data_monthly <- ts_data %>% 
+    mutate(year = lubridate::year(dateTime),
+           month_num = sprintf('%02d', lubridate::month(dateTime))) %>% 
+    group_by(year, month_num) %>% 
+    summarize(SpecCond_avg = mean(SpecCond), .groups="keep") %>% 
+    ungroup() %>% 
+    pivot_wider(names_from = month_num, values_from = SpecCond_avg) %>% 
+    # Arrange columns so January is first, then replace with abbreviations instead of numbers
+    relocate(year, order(names(.))) %>% 
+    rename_with(~month.abb[as.numeric(.x)], -year)
+  
+  # Convert the data into a `ts` object to pass to `SeasonalMannKendall()`
+  smk_data <- ts_data_monthly %>% 
+    # Remove the `year` column so that just the data is converted to a `ts` obj
+    dplyr::select(-year) %>% 
+    ts(start = c(min(ts_data_monthly$year), 1), frequency = 1)
+  
+  # Run the Seasonal Mann-Kendall model and extract the trend result
+  smk_data %>% 
+    Kendall::SeasonalMannKendall() %>% 
+    extract_mk_trend(max_pval = max_pval)
+  
+}
+
+#' @title Extract the trend from MannKendall (MK output)
+#' @description Use the output from a `Kendall::MannKendall()` or 
+#' `Kendall::SeasonalMannKendall()` model run to categorize the trend
+#' as either `none`, `positive`, or `negative`. 
+#' 
+#' @param mk_output a model object of the class `Kendall` from running either
+#' `Kendall::MannKendall()` or `Kendall::SeasonalMannKendall()`.
+#' @param max_pval numeric value indicating the maximum p-value that is
+#' allowed to declare a trend significant. Any model output with a p-value
+#' above this value will have return "none" for the trend. Defaults to 0.05.
+#' 
+#' @return a character string indicating the trend as "none", "positive", or "negative"
+#' 
+extract_mk_trend <- function(mk_output, max_pval = 0.05) {
+  
+  # Extract the pvalue programmatically
+  pval <- capture.output(summary(mk_output))[3] %>% 
+    str_split_1("pvalue =") %>% tail(1)
+  
+  # Drop the '<' that can sometimes be present for
+  # super small numbers.
+  pval <- as.numeric(gsub('< ', '', pval))
+  
+  # Return the appropriate trend name based on the
+  # MannKendall `Score` (aka S) but only if the
+  # p-value was below `max_pval`.
+  if(pval >= max_pval | mk_output$S == 0) {
+    trend <- "none"
+  } else if(mk_output$S < 0) {
+    trend <- "negative"
+  } else if(mk_output$S > 0) {
+    trend <- "positive"
+  }
+  
+  return(trend)
+}
+
 #' @title Aggregate road salt application values per site
 #' @description Extract and sum cell values from the road salt raster file
 #' to get a single road salt application rate value for each site.

--- a/2_Prepare/src/ts_detrend_fxns.R
+++ b/2_Prepare/src/ts_detrend_fxns.R
@@ -1,0 +1,80 @@
+
+#' @title Filter only to sites that have all available data
+#' @description The detrending algorithm will not work if there are any
+#' missing values in the timeseries. This identifies only those sites that
+#' have complete records to use as an argument in `detrend_sc_data()`. It will
+#' check against the column that contains the gap-filled data, `[PARAM]_fill`
+#' 
+#' @param ts_data a tibble with at least the columns `site_no` and `[PARAM]`
+#' @param param_colname a character string indicating the name used in the columns 
+#' for the data values. In this workflow, this is likely `SpecCond`.
+#'  
+#' @return a vector of site numbers
+#' 
+identify_sites_to_detrend <- function(ts_data, param_colname) {
+  ts_data %>% 
+    # Temporarily rename the data column so that this can handle any param
+    rename_with(~gsub(param_colname, 'PARAM', .x)) %>% 
+    # By site, identify if the column has any NA values
+    group_by(site_no) %>% 
+    summarize(hasNAs = any(is.na(PARAM_fill))) %>% 
+    # If there were any NA values (even just one!), filter out that site
+    filter(!hasNAs) %>% 
+    # Return only the site numbers as a character vector
+    pull(site_no) 
+}
+
+#' @title Detrend a timeseries
+#' @description Detrend a timeseries by site using functions and packages from
+#' the `tidyverts` collection of "tidy tools for time series analysis", including
+#' `tsibble` and `feasts`. This can handle data from one or more sites at a time
+#' but the detrending algorithm, `feasts::STL()`, only works for complete timeseries
+#' record and will error if there are NAs (hence the `sites_to_detrend` argument).
+#' 
+#' @param ts_data a tibble with at least the columns `site_no`, `dateTime`, 
+#' `[PARAM]`, and `[PARAM]_fill` (gap-filled column)
+#' @param sites_to_detrend character vector of site numbers that don't have any
+#' missing data as identified by `identify_sites_to_detrend()`.
+#' @param param_colname a character string indicating the name used in the columns 
+#' for the data values. In this workflow, this is likely `SpecCond`.
+#' 
+#' @return tibble with the columns `site_no`, `dateTime`, `SpecCond` (original 
+#' values), `SpecCond_fill` (gap-filled values), and `SpecCond_detrend` (gap-filled
+#' values that no longer have a trend).
+#' 
+detrend_ts_data <- function(ts_data, sites_to_detrend, param_colname) {
+  
+  ts_data_to_detrend <- ts_data %>% 
+    # Only keep sites that did not have any missing data
+    filter(site_no %in% sites_to_detrend) %>%  
+    # Temporarily rename the data column so that this can handle any param
+    rename_with(~gsub(param_colname, 'PARAM', .x)) 
+  
+  ts_data_to_detrend %>% 
+    # Convert to a timeseries tibble, tsibble
+    # using the dateTime column as the time component
+    # and specifying the site_no as the `key` (meaning
+    # treating as separate timeseries)
+    as_tsibble(index = dateTime, key = site_no) %>% 
+    # Apply the STL model to the gap-filled 
+    # values and use an annual period
+    model(STL(PARAM_fill ~ season(period = '1 year'))) %>% 
+    # Extract values from the model as columns
+    components() %>% 
+    # Compute the "detrended" 
+    mutate(PARAM_detrend = PARAM_fill - trend) %>%
+    # Convert back to a regular tibble (not ts tibble)
+    as_tibble() %>% 
+    # Add the original PARAM column back in (removed because 
+    # it was not a column used during the model step)
+    mutate(PARAM = ts_data_to_detrend$PARAM) %>% 
+    # Return only the necessary columns
+    dplyr::select(site_no, 
+                  dateTime, 
+                  PARAM,
+                  PARAM_fill,
+                  PARAM_detrend) %>% 
+    # Reverse the temporary column names back to the original 
+    rename_with(~gsub('PARAM', param_colname, .x))
+  
+}

--- a/2_Prepare/src/ts_gap_fxns.R
+++ b/2_Prepare/src/ts_gap_fxns.R
@@ -68,9 +68,8 @@ interpolate_gaps <- function(ts_data, ids_to_interp, param_colname) {
 #' @description Identify, fill, and announce gap-filling. This is 
 #' currently setup to use linear interpolation via `interpolate_gaps()` 
 #' to fill gaps that meet gap-filling maximums, determined by 
-#' `identify_acceptable_gaps()`. Note that if `-999999` appears in the 
-#' data, it is replaced by an NA *before* gaps are identified and filled. This
-#' assumes that the data passed in is for only one site.
+#' `identify_acceptable_gaps()`. This assumes that the data passed in is for 
+#' only one site.
 #' 
 #' @param ts_data a tibble with at least the columns `site_no`, `dateTime`, and `[PARAM]`
 #' @param param_colname a character string indicating the name used in the columns 
@@ -91,9 +90,7 @@ fill_ts_gaps <- function(ts_data, param_colname, max_gap_days) {
     # Join in the real data
     left_join(ts_data, by = c('site_no', 'dateTime')) %>% 
     # Temporarily rename the data column so that this can handle any param
-    rename_with(~gsub(param_colname, 'PARAM', .x)) %>% 
-    # Replace the -999999 code with NAs before counting & filling gaps
-    mutate(PARAM = na_if(PARAM, -999999))
+    rename_with(~gsub(param_colname, 'PARAM', .x)) 
   
   # Create a vector of the row indices that qualify to be filled
   row_ids_to_fill <- identify_acceptable_gaps(ts_data_all_days[['PARAM']], 

--- a/2_Prepare/src/ts_gap_fxns.R
+++ b/2_Prepare/src/ts_gap_fxns.R
@@ -1,0 +1,167 @@
+
+#' @title Identify gaps that can be filled
+#' @description Count the length of gaps by identifying how many NAs appear
+#' multiple days in a row. Filter to only gaps that are below a max number of 
+#' days and return a vector of indices that refer to the input vector. Note
+#' that this assumes you've only passed in one site's data at a time.
+#' 
+#' @param data_vector vector of values where some might be NA
+#' @param max_gap_days single numeric value indicating the maximum 
+#' number of sequential values that can be NA
+#' 
+#' @return numeric vector of the indices that have passed the criteria for being 
+#' gap-filled; indices correspond to the input vector, `data_vector`
+#' 
+identify_acceptable_gaps <- function(data_vector, max_gap_days) {
+  
+  # Count how many NA values appear sequentially
+  acceptableNA_sequences <- accelerometry::rle2(
+    x = is.na(data_vector), 
+    indices = TRUE) %>% as_tibble() %>% 
+    # value == 0 means "FALSE" to is.na(), keep those
+    # value == 1 means "TRUE" to is.na(), only keep if they are < max gap allowed
+    filter(value == 0 | value == 1 & length <= max_gap_days)
+  
+  # Use the `start` and `stop` fields returned by `rle2` to create
+  # a vector of the indices.
+  acceptable_ids <- apply(acceptableNA_sequences, 1, 
+                          function(x) seq(x[['start']], x[['stop']])) %>% 
+    reduce(c)
+  
+  return(acceptable_ids)
+}
+
+#' @title Linearly interpolate to fill data gaps
+#' @description Apply linear interpolation to fill data gaps. Only fills gaps
+#' in rows that correspond to the input parameter `ids_to_interp`. All other
+#' gaps will remain NAs.
+#' 
+#' @param ts_data a tibble with at least the `[PARAM]` column and a row for each 
+#' day; designed for use within `fill_ts_gaps()` 
+#' @param ids_to_interp vector of row indices that can be filled, output 
+#' of `identify_acceptable_gaps()`
+#' @param param_colname a character string indicating the name used in the columns 
+#' for the data values. In this workflow, this is likely `SpecCond`.
+#' 
+#' @return tibble with an additional column called `[PARAM]_adj`, containing the 
+#' gap-filled values (may still have some NAs)
+#' 
+interpolate_gaps <- function(ts_data, ids_to_interp, param_colname) {
+  ts_data %>% 
+    # Temporarily rename the data column so that this can handle any param
+    rename_with(~gsub(param_colname, 'PARAM', .x)) %>% 
+    # Linear interpolate with ALL dates and values available (doing ALL and 
+    # THEN replacing with NA afterwards so that the interpolation
+    # uses appropriate data points to fill).
+    mutate(PARAM_interp = zoo::na.approx(PARAM, na.rm = FALSE)) %>% 
+    # Now replace interpolated values with `NA` for any of those
+    # rows where we think the gap is too big to accept the interpolation
+    mutate(PARAM_adj = ifelse(row_number() %in% ids_to_interp,
+                              PARAM_interp, NA)) %>% 
+    dplyr::select(-PARAM_interp) %>% 
+    ungroup() %>% 
+    # Reverse the `PARAM` placeholder column names 
+    rename_with(~gsub('PARAM', param_colname, .x))
+}
+
+#' @title Fill gaps in a timeseries
+#' @description Identify, fill, and announce gap-filling. This is 
+#' currently setup to use linear interpolation via `interpolate_gaps()` 
+#' to fill gaps that meet gap-filling maximums, determined by 
+#' `identify_acceptable_gaps()`. Note that if `-999999` appears in the 
+#' data, it is replaced by an NA *before* gaps are identified and filled. This
+#' assumes that the data passed in is for only one site.
+#' 
+#' @param ts_data a tibble with at least the columns `site_no`, `dateTime`, and `[PARAM]`
+#' @param param_colname a character string indicating the name used in the columns 
+#' for the data values. In this workflow, this is likely `SpecCond`.
+#' @param max_gap_days single numeric value indicating the maximum number of 
+#' sequential values that can be NA; passed on to `identify_acceptable_gaps()`
+#' 
+#' @return tibble with an additional column called `[PARAM]_adj`, containing the 
+#' gap-filled values (may still have some NAs) and additional rows so that the 
+#' data has one for each day between the min and max dates).
+#' 
+fill_ts_gaps <- function(ts_data, param_colname, max_gap_days) {
+  # Start by creating a data frame with all possible days for each site
+  ts_data_all_days <- tibble(site_no = unique(ts_data$site_no),
+                             dateTime = seq(min(ts_data$dateTime), 
+                                            max(ts_data$dateTime),
+                                            by = 'days')) %>% 
+    # Join in the real data
+    left_join(ts_data, by = c('site_no', 'dateTime')) %>% 
+    # Temporarily rename the data column so that this can handle any param
+    rename_with(~gsub(param_colname, 'PARAM', .x)) %>% 
+    # Replace the -999999 code with NAs before counting & filling gaps
+    mutate(PARAM = na_if(PARAM, -999999))
+  
+  # Create a vector of the row indices that qualify to be filled
+  row_ids_to_fill <- identify_acceptable_gaps(ts_data_all_days[['PARAM']], 
+                                              max_gap_days = 5)
+  
+  ts_data_all_days %>% 
+    # Reverse the temporary column name before passing to `interpolate_gaps()`
+    # because it will also rename them temporarily.
+    rename_with(~gsub('PARAM', param_colname, .x)) %>% 
+    # Fill the gaps!
+    interpolate_gaps(row_ids_to_fill, param_colname) 
+}
+
+#' @title Summarize counts of pre- and post-gap filling.
+#' @description Tally counts site-years that now qualify for dynamic time-warping
+#' algorithms because there are no NAs. Includes counts of how many site-year
+#' timeseries qualified before and after the gap-filling. This should have all
+#' sites' data passed in at once.
+#' 
+#' @param ts_filled_data a tibble with at least the columns `site_no`, `dateTime`,
+#' `[PARAM]`, and `[PARAM]_adj`; expects the output of fill_ts_gaps
+#' @param param_colname a character string indicating the name used in the columns 
+#' for the data values. In this workflow, this is likely `SpecCond`.
+#' 
+#' @return a tibble with the columns XXX
+
+summarize_gap_fixes <- function(ts_filled_data, param_colname) {
+  
+  # How many site-years are now available?
+  ts_filled_info <- ts_filled_data %>%
+    mutate(year = year(dateTime)) %>%
+    # Temporarily rename the data column so that this can handle any param
+    rename_with(~gsub(param_colname, 'PARAM', .x)) %>% 
+    group_by(site_no, year) %>%
+    # Add columns that say whether or not NAs appear in the data for this
+    # specific site-year. If there are NAs, that timeseries would be 
+    # removed before getting used in the clustering algorithms.
+    summarize(use_before = !any(is.na(PARAM)),
+              use_after = !any(is.na(PARAM_adj)),
+              .groups = 'keep') %>%
+    ungroup()
+  
+  # How many site-year combos did we have before gap-filling?
+  ts_usable_before <- ts_filled_info %>% filter(use_before) %>% nrow()
+  # n=1600
+  
+  # How many were saved? Meaning the gap-filling removes
+  # all NAs in that site-year timeseries so it can be used.
+  ts_saved <- ts_filled_info %>% filter(!use_before & use_after) %>% nrow()
+  # n=2137
+  
+  # How many couldn't be saved? There were still NAs after
+  # gap-filling attempts (too many large gaps?)
+  ts_still_unusable <- ts_filled_info %>% filter(!use_before & !use_after) %>% nrow()
+  # n=5299
+  
+  # So how many site-years do we have to work with after gap-filling?
+  ts_usable_now <- ts_filled_info %>% filter(use_after) %>% nrow()
+  # n=3737
+  
+  tibble(status = c('All site-year ts in data',
+                    'TS usable before gap-filling',
+                    'TS usable thanks to gap-filling',
+                    'TS still unusable',
+                    'All site-year ts now usable'),
+         num_ts = c(nrow(ts_filled_info),
+                    ts_usable_before, 
+                    ts_saved, 
+                    ts_still_unusable, 
+                    ts_usable_now))
+}

--- a/2_Prepare/src/ts_gap_fxns.R
+++ b/2_Prepare/src/ts_gap_fxns.R
@@ -43,7 +43,7 @@ identify_acceptable_gaps <- function(data_vector, max_gap_days) {
 #' @param param_colname a character string indicating the name used in the columns 
 #' for the data values. In this workflow, this is likely `SpecCond`.
 #' 
-#' @return tibble with an additional column called `[PARAM]_adj`, containing the 
+#' @return tibble with an additional column called `[PARAM]_fill`, containing the 
 #' gap-filled values (may still have some NAs)
 #' 
 interpolate_gaps <- function(ts_data, ids_to_interp, param_colname) {
@@ -56,7 +56,7 @@ interpolate_gaps <- function(ts_data, ids_to_interp, param_colname) {
     mutate(PARAM_interp = zoo::na.approx(PARAM, na.rm = FALSE)) %>% 
     # Now replace interpolated values with `NA` for any of those
     # rows where we think the gap is too big to accept the interpolation
-    mutate(PARAM_adj = ifelse(row_number() %in% ids_to_interp,
+    mutate(PARAM_fill = ifelse(row_number() %in% ids_to_interp,
                               PARAM_interp, NA)) %>% 
     dplyr::select(-PARAM_interp) %>% 
     ungroup() %>% 
@@ -77,7 +77,7 @@ interpolate_gaps <- function(ts_data, ids_to_interp, param_colname) {
 #' @param max_gap_days single numeric value indicating the maximum number of 
 #' sequential values that can be NA; passed on to `identify_acceptable_gaps()`
 #' 
-#' @return tibble with an additional column called `[PARAM]_adj`, containing the 
+#' @return tibble with an additional column called `[PARAM]_fill`, containing the 
 #' gap-filled values (may still have some NAs) and additional rows so that the 
 #' data has one for each day between the min and max dates).
 #' 
@@ -111,7 +111,7 @@ fill_ts_gaps <- function(ts_data, param_colname, max_gap_days) {
 #' sites' data passed in at once.
 #' 
 #' @param ts_filled_data a tibble with at least the columns `site_no`, `dateTime`,
-#' `[PARAM]`, and `[PARAM]_adj`; expects the output of fill_ts_gaps
+#' `[PARAM]`, and `[PARAM]_fill`; expects the output of fill_ts_gaps
 #' @param param_colname a character string indicating the name used in the columns 
 #' for the data values. In this workflow, this is likely `SpecCond`.
 #' 
@@ -129,7 +129,7 @@ summarize_gap_fixes <- function(ts_filled_data, param_colname) {
     # specific site-year. If there are NAs, that timeseries would be 
     # removed before getting used in the clustering algorithms.
     summarize(use_before = !any(is.na(PARAM)),
-              use_after = !any(is.na(PARAM_adj)),
+              use_after = !any(is.na(PARAM_fill)),
               .groups = 'keep') %>%
     ungroup()
   

--- a/2_Prepare/src/ts_nwis_fxns.R
+++ b/2_Prepare/src/ts_nwis_fxns.R
@@ -167,6 +167,7 @@ read_nwis_file <- function(in_file, param_colname) {
     #   renameNWISColumns() %>% 
     #   mutate(SC = ifelse(!is.na(SpecCond), SpecCond, `..2.._SpecCond`))
     # plot(x$dateTime, x$SC)
+    # in_file <- "1_Download/out_nwis/sc_dv_003.feather"
     
     # For now, just record which files this occurs in.
     message('Found a file with more than `SpecCond` datastream: ', in_file)

--- a/2_Prepare/src/ts_nwis_fxns.R
+++ b/2_Prepare/src/ts_nwis_fxns.R
@@ -89,6 +89,8 @@ convert_to_date <- function(timeseries_data, site_tz_xwalk) {
 #' @title Combine all downloaded and calculated daily means
 #' @description Using the downloaded NWIS daily data and the output from 
 #' `calculate_dv_from_uv()`, create a single timeseries dataset of daily means.
+#' Note that if the data contains the column `SpecCond` any `-999999` value is 
+#' replaced by an NA. 
 #' 
 #' @param out_file a character string indicating a file path to save a feather 
 #' file of all the daily means
@@ -113,7 +115,12 @@ combine_all_dv_data <- function(out_file, in_files, param_colname) {
     # Combine the list of loaded tables into a single table
     bind_rows() %>% 
     # Arrange so that site's data are together and ordered chronologically
-    arrange(site_no, dateTime) %>% 
+    arrange(site_no, dateTime) %>% {
+      # For SC data, replace the -999999 code with NAs before counting & filling gaps
+      if(param_colname == 'SpecCond')
+        mutate(., SpecCond = na_if(SpecCond, -999999))
+      else .
+    } %>% 
     # Save the data as a file
     write_feather(out_file)
   

--- a/4_ClusterTS.R
+++ b/4_ClusterTS.R
@@ -3,4 +3,8 @@
 
 p4_targets <- list(
   
+  ###### Split SC timeseries into individual site-years ######
+  
+  # TODO: Split SC timeseries into site-years to prep for running DTW
+  
 )

--- a/_targets.R
+++ b/_targets.R
@@ -7,11 +7,13 @@ tar_option_set(
   packages = c(
     'arrow',
     'dataRetrieval',
+    'feasts',
     'nhdplusTools',
     'raster',
     'sbtools',
     'sf',
-    'tidyverse'
+    'tidyverse',
+    'tsibble'
   ), 
   format =  'qs',
   workspace_on_error = TRUE


### PR DESCRIPTION
Fixes #29 (but with some remaining questions to be addressed in a meeting when Hilary returns). 

Clean up SC time series data (list below) AND add SC trend as an attribute (adds 3 different types of trends right now).

1. Replace any SC value of `-999999` with NA
2. Fill gaps using linear interpolation for those that are < 5 days (this resulted in 2,137 more site-year time series without NAs, see table below)
3. Apply trend decomposition algorithm (`feasts::STL()`) to SC time series (this only works on the 9 sites that currently have complete records, no NAs anywhere along the way)

```r
targets::tar_read(p2_ts_sc_dv_gapSummary)

 status                          num_ts
All site-year ts in data          9036
TS usable before gap-filling      1600
TS usable thanks to gap-filling   2137
TS still unusable                 5299
All site-year ts now usable       3737
```