### PR TITLE
Redo salt calculation - use NHD catchments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ _targets/*
 */tmp/*
 */out/*
 1_Download/out_nwis/*
+1_Download/out_nhdplus/*
 # But allow folder structure to be commited
 #   with a placeholder file
 !*/tmp/.placeholder

--- a/1_Download.R
+++ b/1_Download.R
@@ -279,6 +279,15 @@ p1_targets <- list(
   # is pasture/hay and CAT_NLCD19_82 is cultivated crops). Used during `3_Filter`.
   tar_target(p1_nhdplus_ag_vals_tbl, 
              download_nhdplus_attributes(attributes = c('CAT_NLCD19_81', 'CAT_NLCD19_82'),
-                                         comids = unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid)))
+                                         comids = unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid))),
+  
+  # Download NHD+ catchment data
+  tar_target(p1_nhdplus_comids, na.omit(unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid))),
+  tar_target(p1_nhdplus_catchments_gpkg, 
+             download_nhdplus_catchments(out_file = sprintf('1_Download/out_nhdplus/nhdplus_catchment_%s.gpkg',
+                                                            p1_nhdplus_comids),
+                                         comids = p1_nhdplus_comids),
+             pattern = map(p1_nhdplus_comids), 
+             format = 'file')
   
 )

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -7,6 +7,8 @@ source('2_Prepare/src/ts_detrend_fxns.R')
 source('2_Prepare/src/ts_finalize_fxns.R')
 source('2_Prepare/src/attr_prep_fxns.R')
 source('2_Prepare/src/attr_combine_all.R')
+source('2_Prepare/src/extract_nhdplus_geopackage_layer.R')
+
 
 p2_targets <- list(
   
@@ -135,8 +137,18 @@ p2_targets <- list(
   
   ###### ATTR DATA 2: Extract road salt application per site ######
   
-  tar_target(p2_attr_roadSalt, aggregate_road_salt_per_site(road_salt_tif = p1_sb_road_salt_2015_tif, 
-                                                            sites_sf = p1_nwis_sc_sites_sf)),
+  # TODO: currently only summing each catchment. Should we be using all upstream? That would require downloading way more catchments.
+  # TODO: not all sites are mapped to COMIDs or had catchments available. We could look at using 5 km radius for site's without catchment polys.
+  
+  # First, extract the catchments as polygons
+  tar_target(p2_nhdplus_catchment_sf, extract_nhdplus_geopackage_layer(p1_nhdplus_catchments_gpkg)),
+  
+  # Second, summarize total salt per catchment
+  tar_target(p2_nhdplus_catchment_salt, aggregate_road_salt_per_poly(road_salt_tif = p1_sb_road_salt_2015_tif, 
+                                                                     polys_sf = p2_nhdplus_catchment_sf)),
+  
+  # Then, map total salt for each NHD COMID catchment polygon to sites
+  tar_target(p2_attr_roadSalt, map_catchment_roadSalt_to_site(p2_nhdplus_catchment_salt, p1_nwis_site_nhd_comid_xwalk)),
   
   ###### ATTR DATA 3: Calculate SC trend per site ######
   

--- a/2_Prepare/src/extract_nhdplus_geopackage_layer.R
+++ b/2_Prepare/src/extract_nhdplus_geopackage_layer.R
@@ -1,0 +1,53 @@
+
+#' @title Extract specific layers from the downloaded geopackages
+#' @description Open and pull a specific layer from the saved NHD+ geopackages. 
+#' Noting that sometimes a COMID does not have all available layers. 
+#' 
+#' @param in_files a character vector of filepaths to the geopackages downloaded
+#' using `nhdplusTools::subset_nhdplus()`.
+#' @param gpkg_layer a character value of either `CatchmentSP` or `NHDFlowline_Network` 
+#' to indicate which of the geopackage layers to extract. Defaults to `CatchmentSP`.
+#' @param crs_out the EPSG code indicating which projection to transform the 
+#' output spatial features object to before returning
+#' 
+#' @returns an `sf` data frame with a row for each spatial feature. Should have the
+#' same number of rows as `in_files` but sometimes a geopackage will not have the
+#' layer and therefore will not have anything to return.
+#' 
+extract_nhdplus_geopackage_layer <- function(in_files, gpkg_layer = 'CatchmentSP', crs_out = 4326) {
+  
+  # Identify which geopackages have the layer requested
+  gpkg_has_layer <- purrr::map(in_files, ~{
+    gpkg_layer %in% st_layers(.x)$name
+  }) %>% reduce(c) 
+  
+  # Print a message about how many are missing this layer
+  message(sprintf('Note that %s gpkg files do not have the %s layer', 
+                  sum(!gpkg_has_layer), gpkg_layer))
+  
+  # Extract the layer for geopackages where it exacts and return as a single
+  # `sf` table where each spatial feature has been appropriately transformed.
+  map(in_files[gpkg_has_layer], ~{
+    st_read(.x, gpkg_layer, quiet = TRUE) %>%
+      st_transform(crs = crs_out) %>% {
+        if(gpkg_layer == 'NHDFlowline_Network') {
+          # Now fix issues for the flowlines layer so that we can bind columns that are different types
+          mutate(hwtype = ifelse(hwtype == " ", NA, hwtype)) %>% 
+            # In particular, there is a general issue where NA columns become character
+            # and should be numeric & sometimes `elevfixed` gets a value of "0" and should be numeric
+            mutate(across(where(is.character) & (where(is.na) | elevfixed), as.numeric)) 
+        } else {
+          .
+        }
+      }
+  }) %>%
+    bind_rows() %>% {
+      # CatchmentSP uses `featureid` for the comid and `NHDFlowline_Network` uses `comid`
+      # Rename to the same thing here 
+      if(gpkg_layer == 'CatchmentSP') {
+        rename(., nhd_comid = 'featureid')
+      } else {
+        rename(., nhd_comid = 'comid')
+      }
+    }
+}

--- a/2_Prepare/src/extract_nhdplus_geopackage_layer.R
+++ b/2_Prepare/src/extract_nhdplus_geopackage_layer.R
@@ -32,7 +32,7 @@ extract_nhdplus_geopackage_layer <- function(in_files, gpkg_layer = 'CatchmentSP
       st_transform(crs = crs_out) %>% {
         if(gpkg_layer == 'NHDFlowline_Network') {
           # Now fix issues for the flowlines layer so that we can bind columns that are different types
-          mutate(hwtype = ifelse(hwtype == " ", NA, hwtype)) %>% 
+          mutate(., hwtype = ifelse(hwtype == " ", NA, hwtype)) %>% 
             # In particular, there is a general issue where NA columns become character
             # and should be numeric & sometimes `elevfixed` gets a value of "0" and should be numeric
             mutate(across(where(is.character) & (where(is.na) | elevfixed), as.numeric)) 


### PR DESCRIPTION
Instead of summing the road salt raster values in a 5 km radius around each site to get total salt applied per site, we are summing road salt raster values for the NHD+ catchment polygons for each site. This is a more accurate picture of salt that may make its way into the stream. 

Two current missing or other ideas to explore:
1. Missing catchment. For two sites, we are missing either a linked COMID or NHD+ did not have a catchment shape for the COMID. In these cases, we don't currently have any salt value. If these sites are being used in our final data, we should figure out a solution. Maybe go back to assumed radius of salt?
2. No upstream catchments. We are not currently including upstream catchments in these total salt calculations. Only the catchment that the site is in are included. 

The overall magnitude of the salt dropped quite a bit with this new method (though likely more accurate for our purposes). However, there are not quite the extremes here that there were in the 5 km radius calculation.

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/dd05d205-6513-4741-aaca-643e18015fa2)

