### PR TITLE
Stub in *new* episodic vs baseflow methods approach & initial RF

### DIFF
--- a/4_EpisodicSalinization.R
+++ b/4_EpisodicSalinization.R
@@ -1,0 +1,17 @@
+# Targets for identifying sites that exhibit "episodic salinization"
+
+# TODO: change the name once we are happy with skipping clustering. Don't want
+# to overwrite those targets yet since they were *LENGTHY* to build.
+p4b_targets <- list(
+  
+  # TODO: Actually add the methods Hilary used.
+  tar_target(p4b_episodic_sites, c("01095434", "01104415", "01104420", "01104455", "01104460", 
+                                  "01645704", "01645762", "01646000", "01646305", "01654000", "01656903", 
+                                  "03098600", "03099500", "03106000", "03293000", "03302000", "04119400", 
+                                  "04142000", "04157005", "04165500", "04166500", "04176500", "04199500", 
+                                  "04200500", "04208000", "05289800", "06894000", "01104370", "01400500", 
+                                  "01408000", "01408029", "01481500", "01573695", "01573710", "01649190", 
+                                  "01649500", "01650800", "03254550", "03262001", "03277075", "040851385", 
+                                  "040871488", "06893390", "06893620", "06893820", "06893970"))
+  
+)

--- a/5_BaseflowSalinization.R
+++ b/5_BaseflowSalinization.R
@@ -1,0 +1,9 @@
+# Targets for identifying sites that exhibit "baseflow salinization"
+
+# TODO: change the name once we are happy with skipping clustering. Don't want
+# to overwrite yet.
+p5b_targets <- list(
+  
+  tar_target(p5b_baseflow_sites, c())
+  
+)

--- a/5_DefineClusters.R
+++ b/5_DefineClusters.R
@@ -1,10 +1,10 @@
 # Targets for applying a random forest to link attributes
 # to each timeseries cluster from `4_ClusterTS`
 
-source('5_DefineClusters/src/prep_attr_randomforest.R')
-source('5_DefineClusters/src/visualize_attributes_bycluster.R')
-source('5_DefineClusters/src/apply_randomforest.R')
-source('5_DefineClusters/src/evaluate_randomforest.R')
+# source('5_DefineClusters/src/prep_attr_randomforest.R')
+# source('5_DefineClusters/src/visualize_attributes_bycluster.R')
+# source('5_DefineClusters/src/apply_randomforest.R')
+# source('5_DefineClusters/src/evaluate_randomforest.R')
 
 p5_targets <- list(
   

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -1,0 +1,49 @@
+# Targets for applying a random forest to link attributes
+# to each site that is experiencing "episodic salinization"
+# or "baseflow salinization" or both.
+
+source('6_DefineCharacteristics/src/prep_attr_randomforest.R')
+source('6_DefineCharacteristics/src/apply_randomforest.R')
+source('6_DefineCharacteristics/src/evaluate_randomforest.R')
+source('6_DefineCharacteristics/src/visualize_attribute_distributions.R')
+
+p6_targets <- list(
+  
+  ##### Prep data for RF #####
+  
+  tar_target(p6_site_attr_rf, prep_attr_randomforest(p3_static_attributes, p4b_episodic_sites, p5b_baseflow_sites)),
+  
+  ##### Determine optimal RF configs #####
+  
+  tar_target(p6_rf_model_initial, apply_randomforest(p6_site_attr_rf)),
+  
+  # Find and use optimal `mtry` to minimize OOB error
+  tar_target(p6_mtry_optimal_all_attrs, optimize_mtry(p6_site_attr_rf)),
+  tar_target(p6_rf_model_minOOB, apply_randomforest(p6_site_attr_rf, p6_mtry_optimal_all_attrs)),
+  
+  # Trim the number of attributes used by only choosing those that appeared as
+  # one of the top 10 most important in one of the categories.
+  tar_target(p6_site_attr_rf_optimal, optimize_attrs(p6_site_attr_rf, p6_rf_model_minOOB)),
+  
+  # Now with the new site attributes re-calculate the optimal `mtry`
+  tar_target(p6_mtry_optimal, optimize_mtry(p6_site_attr_rf_optimal)),
+  
+  ##### Run optimal RF #####
+  
+  tar_target(p6_rf_model_optimal, apply_randomforest(p6_site_attr_rf_optimal, p6_mtry_optimal)),
+  
+  ##### Evaluate RF output #####
+  
+  tar_target(p6_rf_attr_importance, calculate_attr_importance(p6_rf_model_optimal)),
+  tar_target(p6_rf_attr_importance_viz, visualize_attr_importance(p6_rf_attr_importance)),
+  tar_target(p6_rf_attr_importance_simple_viz, visualize_attr_importance(p6_rf_attr_importance,
+                                                                         simple = TRUE)),
+  tar_target(p6_rf_attr_partdep, calculate_partial_dependence(p6_rf_model_optimal, 
+                                                              p6_site_attr_rf)),
+  tar_target(p6_rf_attr_partdep_viz, visualize_partial_dependence(p6_rf_attr_partdep)),
+  
+  ##### Visualize site category attribute distributions #####
+  
+  tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal))
+  
+)

--- a/6_DefineCharacteristics/src/apply_randomforest.R
+++ b/6_DefineCharacteristics/src/apply_randomforest.R
@@ -1,0 +1,59 @@
+
+# TODO: DOCUMENTATION
+apply_randomforest <- function(site_attr_data, mtry = NULL) {
+  
+  # Use the default for mtry in `randomForest()` if passed in as NULL here
+  if(is.null(mtry)) mtry <- floor(sqrt(ncol(site_attr_data) - 1))
+  
+  randomForest(
+    site_category_fact ~ .,
+    data = site_attr_data,
+    mtry = mtry, 
+    importance = TRUE)
+  
+}
+
+# TODO: DOCUMENTATION
+optimize_mtry <- function(site_attr_data) {
+  # Need to select the value of mtry that reduces OOB
+  # mtry = number of variables for each tree
+  # OOB = out of bag error
+  mtry <- tuneRF(
+    select(site_attr_data, -site_category_fact),
+    site_attr_data$site_category_fact, 
+    ntreeTry=500,
+    stepFactor=1.5,
+    improve=0.01, 
+    trace=TRUE, 
+    plot=FALSE)
+  best.mtry <- mtry[which.min(mtry[,'OOBError']), 'mtry']
+  return(best.mtry)
+}
+
+# TODO: documentation
+optimize_attrs <- function(site_attr_data, rf_model, n_important = 10) {
+  
+  # Prepare importance values in long table format
+  rf_importance <- rf_model$importance %>% 
+    as_tibble(rownames = 'attribute') %>% 
+    dplyr::select(-MeanDecreaseGini, -MeanDecreaseAccuracy) %>% 
+    pivot_longer(-attribute, 
+                 names_to = 'site_category',
+                 values_to = 'importance') 
+  
+  # Identify top 10 most important attributes for each site category.
+  top10_per_category <- rf_importance %>% 
+    split(.$site_category) %>% 
+    map(~{
+      .x %>% arrange(desc(importance)) %>% head(n_important)
+    }) %>%
+    bind_rows()
+  
+  # Find the unique attributes among all category top 10s.
+  most_important_attrs <- unique(top10_per_category$attribute)
+  
+  # Trim the attribute data down to only that set of unique attributes
+  site_attr_data_trim <- site_attr_data %>% 
+    dplyr::select(site_category_fact, all_of(most_important_attrs))
+  
+}

--- a/6_DefineCharacteristics/src/evaluate_randomforest.R
+++ b/6_DefineCharacteristics/src/evaluate_randomforest.R
@@ -1,0 +1,150 @@
+# TODO: DOCUMENTATION
+calculate_attr_importance <- function(rf_model) {
+  
+  # Prepare importance data
+  rf_importance <- rf_model$importance %>% 
+    as_tibble(rownames = 'attribute') %>% 
+    dplyr::select(-MeanDecreaseGini, -MeanDecreaseAccuracy) %>% 
+    pivot_longer(matches('Both|Baseflow|Episodic|Neither'), 
+                 names_to = 'site_category',
+                 values_to = 'importance') 
+  
+  # Prepare importance SD data
+  rf_importance_sd <- rf_model$importanceSD %>% 
+    as_tibble(rownames = 'attribute') %>% 
+    dplyr::select(-MeanDecreaseAccuracy) %>% 
+    pivot_longer(matches('Both|Baseflow|Episodic|Neither'), 
+                 names_to = 'site_category',
+                 values_to = 'importance_sd')
+  
+  # Prepare mean importance data
+  rf_means_importance <- rf_model$importance %>% 
+    as_tibble(rownames = 'attribute') %>% 
+    mutate(site_category = 'means')  %>% 
+    dplyr::select(attribute, site_category, importance = MeanDecreaseAccuracy) %>% 
+    distinct()
+  
+  # Prepare mean importance SD data
+  rf_means_importance_sd <- rf_model$importanceSD %>% 
+    as_tibble(rownames = 'attribute') %>% 
+    mutate(site_category = 'means') %>% 
+    dplyr::select(attribute, site_category, importance_sd = MeanDecreaseAccuracy) %>% 
+    distinct()
+  
+  # Prepare overall importance table
+  bind_rows(rf_importance, rf_means_importance) %>% 
+    left_join(bind_rows(rf_importance_sd, rf_means_importance_sd), 
+              by = c('attribute', 'site_category')) %>% 
+    dplyr::select(attribute, site_category, everything()) %>% 
+    mutate(attribute_grp = case_when(
+      attribute %in% c('avgSnow', 'avgPrecip', 'avgSnowDetrended', 'pctSnow') ~ 'meteo',
+      attribute %in% c('TrendSeasonalMK', 'TrendMannKendall', 'TrendMannKendall_DS',
+                       'roadSalt', 'meanSoilSalinity') ~ 'salt',
+      attribute %in% c('pctSoilOM', 'avgGWRecharge', 'daysInSubsurface', 'avgSoilStorage',
+                       'pctSoilClay', 'pctSoilSand', 'pctSoilSilt', 'soilPerm', 
+                       'availWaterCap', 'baseFlowInd', 'avgDepth2WT') ~ 'gw',
+      attribute %in% c('vegIndAutumn', 'pctLowDev', 'pctHighDev', 'vegIndSummer',
+                       'vegIndWinter', 'topoWetInd', 'vegIndSpring', 'numDams2013',
+                       'roadStreamXings', 'roadDensity') ~ 'landcover',
+      attribute %in% c('meanFlow', 'avgRunoff', 'avgBasinSlope', 'avgStreamSlope') ~ 'basin',
+      .default = NA_character_
+    ))
+  
+}
+
+# TODO: DOCUMENTATION
+visualize_attr_importance <- function(rf_model_importance, simple = FALSE) {
+  # TODO: save as file
+  
+  # Var importance per site category, ordered by attribute importance
+  plot_list <- rf_model_importance %>% 
+    split(.$site_category) %>% 
+    map(~{
+      # Arrange each category's data based on its own order
+      data_to_plot <- .x %>% 
+        arrange(importance) %>% 
+        mutate(attributef = factor(attribute, ordered = T,
+                                   levels = unique(.$attribute))) %>% 
+        rowwise() %>% 
+        mutate(attribute_grp = ifelse(simple, 'black', attribute_grp))
+      p <- ggplot(data_to_plot, aes(x = importance, y=attributef,
+                                    color = attribute_grp)) +
+        geom_point() +
+        geom_segment(aes(x = importance - importance_sd,
+                         xend = importance + importance_sd,
+                         yend = attributef)) +
+        guides(color = 'none') +
+        theme_bw() +
+        theme(axis.title.y = element_blank(),
+              axis.title.x = element_blank(),
+              axis.text.y = element_text(size=7),
+              title = element_text(size=9, face='bold')) +
+        ggtitle(sprintf('%s', unique(.x$site_category)))
+      if(!simple) p <- p + facet_grid(attribute_grp ~ ., scales='free_y') 
+      if(simple) p <- p + scale_color_identity()
+      return(p)
+    })
+  return(plot_list)
+  # Put all together
+  # cowplot::plot_grid(plotlist = plot_list, nrow = 1)
+}
+
+# TODO: DOCUMENTATION
+# TODO: show partial dependence of two features? 
+# https://christophm.github.io/interpretable-ml-book/pdp.html#examples
+calculate_partial_dependence <- function(rf_model, site_attr_data) {
+  rf_classes <- rf_model$classes
+  
+  numeric_attrs <- rf_model$importance %>% rownames()
+  # TODO: figure out how to evaluate dependence/importance of trends?
+  numeric_attrs <- numeric_attrs[!grepl('Trend', numeric_attrs)]
+  
+  combos <- expand.grid(
+    attribute = numeric_attrs, 
+    site_category = rf_classes, 
+    stringsAsFactors = FALSE)
+  
+  var_partials <- combos %>% 
+    pmap(~{
+      pdp::partial(
+        rf_model,
+        pred.var = .x, 
+        which.class = .y,
+        train = site_attr_data
+      ) %>% setNames(c('attr_val', 'attr_partdep')) %>% 
+        mutate(attribute = .x, 
+               site_category = .y, .before='attr_val')
+    }) %>% 
+    bind_rows()
+}
+
+# TODO: DOCUMENTATION
+visualize_partial_dependence <- function(pdp_data) {
+  ggplot(pdp_data, aes(attr_val, attr_partdep, color = site_category)) +
+    facet_wrap(vars(attribute), scales = 'free_x') +
+    scico::scale_color_scico_d() +
+    geom_line(linewidth = 1) +
+    theme_bw() +
+    theme(strip.background = element_blank())
+}
+
+# TODO: SHAP eval???
+# library(kernelshap)
+# library(shapviz)
+# library(randomForest)
+# 
+# fit <- tar_read(p5_rf_model_optimal)
+# dat <- tar_read(p5_site_attr_rf)
+# 
+# # Step 1: Calculate Kernel SHAP values
+# # bg_X is usually a small (50-200 rows) subset of the data
+# set.seed(19)
+# s <- kernelshap(fit, dat[-1], bg_X = sample_n(dat, 50)) # Just 50 rows took like 30 min
+# s <- kernelshap(fit, dat[-1], bg_X = dat)
+# 
+# # Step 2: Turn them into a shapviz object
+# sv <- shapviz(s)
+# 
+# # Step 3: Gain insights...
+# sv_importance(sv, kind = "bee")
+# sv_dependence(sv, v = "roadSalt", color_var = "auto")

--- a/6_DefineCharacteristics/src/prep_attr_randomforest.R
+++ b/6_DefineCharacteristics/src/prep_attr_randomforest.R
@@ -1,0 +1,35 @@
+
+# TODO: documentation
+prep_attr_randomforest <- function(site_attr_data, sites_episodic, sites_baseflow) {
+  
+  site_attr_data %>% 
+    mutate(site_category = case_when(
+      site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Both',
+      site_no %in% sites_episodic & !site_no %in% sites_baseflow ~ 'Episodic',
+      !site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Baseflow',
+      TRUE ~ 'Neither'
+    )) %>% 
+    # Make the site category a factor so that random forest
+    # is doing classification, not regression
+    mutate(site_category_fact = factor(site_category)) %>% 
+    
+    # TODO: Figure out better way to handle missing data below.
+    
+    # Note that `attr_streamDensity` is missing for 3 sites
+    # and either those sites will need to be removed OR 
+    # the streamDensity attribute cannot be used. 
+    # TODO: Removing that attribute for now.
+    select(-attr_streamDensity) %>% 
+    # One site does not have a match in NHD+, so is missing all attributes - removing
+    filter(site_no != '295501090190400') %>% 
+    # One site is missing road salt (did not have a catchment in NHD+) - removing
+    filter(site_no != '01542500') %>% 
+    
+    # Remove the columns that are not needed for the RF
+    select(site_category_fact, starts_with('attr')) %>% 
+    # Don't need trend attributes
+    select(-starts_with("attr_Trend")) %>% 
+    # Drop the `attr_` prefix so that the results are cleaner
+    rename_with(~gsub("attr_", "", .x))
+  
+}

--- a/6_DefineCharacteristics/src/visualize_attribute_distributions.R
+++ b/6_DefineCharacteristics/src/visualize_attribute_distributions.R
@@ -1,0 +1,18 @@
+# TODO: DOCUMENTATION
+visualize_numeric_attrs <- function(site_attr_data) {
+  # Plotting attribute distributions per cluster
+  data_to_plot <- site_attr_data %>% 
+    dplyr::select(site_category_fact, where(is.numeric)) %>%
+    pivot_longer(cols = -site_category_fact, 
+                 names_to = 'attribute')
+  
+  ggplot(data_to_plot, aes(x = site_category_fact, y = value)) +
+    geom_boxplot(aes(fill = site_category_fact)) + 
+    facet_wrap(vars(attribute), scales = 'free_y') +
+    theme_bw() +
+    scico::scale_fill_scico_d() +
+    xlab('Site Category') + ylab('Attribute value (various scales and units)') +
+    ggtitle('Attributes by site categorization',
+            subtitle = 'Note that we have not yet implemented baseflow methods') +
+    theme(strip.background = element_rect(fill = 'white', color = 'transparent'))
+}

--- a/_targets.R
+++ b/_targets.R
@@ -26,10 +26,16 @@ tar_option_set(
 source('1_Download.R')
 source('2_Prepare.R')
 source('3_Filter.R')
+source('4_EpisodicSalinization.R')
+source('5_BaseflowSalinization.R')
+source('6_DefineCharacteristics.R')
+
+# TODO: DELETE THESE LATER
 source('4_ClusterTS.R')
 source('5_DefineClusters.R')
 
 select <- dplyr::select # The raster pkg keeps overriding this one so make sure this is correct
 
 c(p1_targets, p2_targets, p3_targets,
-  p4_targets, p5_targets)
+  p4_targets, p5_targets, # TODO: DELETE THESE ONES!
+  p4b_targets, p5b_targets, p6_targets)


### PR DESCRIPTION
This PR contains code that adds the episodic vs baseflow methods. It also includes initial code to run a random forest based on site attributes belonging to episodic, baseflow, both, or neither site type. This doesn't delete anything from the old methods yet ... but I will eventually let go of it :)

Some of the outcomes based on only having that initial list of episodic sites from Hilary (I will add the code that finds these sites later).

#### Importance by attribute category 
`cowplot::plot_grid(plotlist = targets::tar_read(p6_rf_attr_importance_viz)[c(1,3)], nrow=1)`

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/341ecb80-64f7-4aad-bb49-ca94ad9d67c1)

#### Importance for site types 
`cowplot::plot_grid(plotlist = targets::tar_read(p6_rf_attr_importance_simple_viz)[c(1,3)], nrow=1)`

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/027d340e-f2be-4bc3-9e30-8e2a8887a666)

#### Partial dependence plots 
`tar_read(p6_rf_attr_partdep_viz)`

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/bfdda1c3-6c98-4aee-a309-a8965344ddab)
