### PR TITLE
Add calculation of upstream salt

### DIFF
--- a/1_Download.R
+++ b/1_Download.R
@@ -257,7 +257,7 @@ p1_targets <- list(
              identify_site_comids(p1_nwis_sc_sites_sf),
              pattern = map(p1_nwis_sc_sites_sf)),
   
-  ###### Download desired static catchment attributes from NHDPlus #####
+  ###### Download desired catchment polygons and static attributes from NHDPlus #####
   
   # Wieczorek, M.E., Jackson, S.E., and Schwarz, G.E., 2018, Select Attributes for 
   #   NHDPlus Version 2.1 Reach Catchments and Modified Network Routed Upstream Watersheds 
@@ -281,13 +281,42 @@ p1_targets <- list(
              download_nhdplus_attributes(attributes = c('CAT_NLCD19_81', 'CAT_NLCD19_82'),
                                          comids = unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid))),
   
-  # Download NHD+ catchment data
+  # Prepare COMIDs to download so that polygons are only downloaded and stored once
   tar_target(p1_nhdplus_comids, na.omit(unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid))),
+  tar_target(p1_nhdplus_comids_upstream, identify_upstream_comids(p1_nhdplus_comids), map(p1_nhdplus_comids)), # Identify upstream COMIDs
+  tarchetypes::tar_group_count(p1_nhdplus_comids_grp, 
+                               count = 500, # Set 500 groups to map over
+                               # Create unique vector of COMIDs to download catchments only once
+                               tibble(nhd_comid = unique(c(p1_nhdplus_comids, p1_nhdplus_comids_upstream$nhd_comid_upstream)))),
+  
+  # Download the full NHD+ seamless National database as a geopackage and then subset after
+  # to avoid annoying errors with `arguments having different crs` in `subset_nhdplus()`
+  tar_target(p1_nhdplus_national_7z, {
+    out_dir <- '1_Download/out_nhdhr_network'
+    
+    # Attempt 1: use `nhdplusTools::download_nhdplusv2` but it mysteriously stops and doesn't finish the download.
+    # download_nhdplusv2(out_dir)
+    
+    # Attempt 2: use `download.file` and the URL to the file on the EPA website to manually 
+    # download the https://www.epa.gov/waterdata/nhdplus-national-data.
+    # download.file(url = 'https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NationalData/NHDPlusV21_NationalData_Seamless_Geodatabase_Lower48_07.7z',
+    #               destfile = out_file)
+    
+    # Attempt 3: manually download the file from the EPA site and move into the folder I want
+    out_file <- file.path(out_dir, 'NHDPlusV21_NationalData_Seamless_Geodatabase_Lower48_07.7z')
+    
+    return(out_file)
+    }, format = 'file'),
+  # TODO: THIS FAILED WITH: Last error: archive_extract.cpp:166 archive_read_next_header(): Truncated 7-Zip file body
+  tar_target(p1_nhdplus_national_gpkg, archive_extract(p1_nhdplus_national_7z, dir = '1_Download/out_nhdhr_network'), format='file'),
+  
+  # Download NHD+ catchment polygons by groups of COMIDs (should be 500 total branches)
   tar_target(p1_nhdplus_catchments_gpkg, 
              download_nhdplus_catchments(out_file = sprintf('1_Download/out_nhdplus/nhdplus_catchment_%s.gpkg',
-                                                            p1_nhdplus_comids),
-                                         comids = p1_nhdplus_comids),
-             pattern = map(p1_nhdplus_comids), 
+                                                            unique(p1_nhdplus_comids_grp$tar_group)),
+                                         comids = p1_nhdplus_comids_grp$nhd_comid,
+                                         p1_nhdplus_national_gpkg),
+             pattern = map(p1_nhdplus_comids_grp), 
              format = 'file')
   
 )

--- a/1_Download/src/nhdplus_fxns.R
+++ b/1_Download/src/nhdplus_fxns.R
@@ -175,7 +175,7 @@ load_nhdplus_attribute_list <- function(in_file) {
 #' 
 #' @return the string to the local geopackage saved
 #' 
-download_nhdplus_catchments <- function(out_file, comids, local_nhdplus_gpkg) {
+download_nhdplus_catchments <- function(out_file, comids) {
   # Some of the nhdplusTools errors still return the geometry we need.
   # So, let's catch those and continue for now.
   # I logged the issues here: https://github.com/DOI-USGS/nhdplusTools/issues/376
@@ -183,19 +183,22 @@ download_nhdplus_catchments <- function(out_file, comids, local_nhdplus_gpkg) {
     sf::sf_use_s2(FALSE)
     subset_nhdplus(comids = as.integer(comids),
                    output_file = out_file,
-                   nhdplus_data = local_nhdplus_gpkg, 
+                   nhdplus_data = "download", 
                    flowline_only = FALSE,
                    return_data = FALSE, 
                    overwrite = TRUE)
   }, error = function(e) {
     if(grepl('st_cast for MULTIGEOMETRYCOLLECTION not supported', e$message) |
        grepl('nrow(x) == length(value) is not TRUE', e$message, fixed=T) |
-       grepl('Loop 0 is not valid: Edge 11 crosses edge 13', e$message)) {
+       grepl('Loop 0 is not valid: Edge 11 crosses edge 13', e$message) |
+       grepl('arguments have different crs', e$message)) {
       warning(sprintf('Caught error but could continue ... %s', e$message))
       return(out_file)
     } else {
       stop(e$message)
     }
+  }, warning = function(w) {
+    warning(sprintf('Caught error but could continue ... %s', w$message))
   })
   
   return(out_file)

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -137,17 +137,19 @@ p2_targets <- list(
   
   ###### ATTR DATA 2: Extract road salt application per site ######
   
-  # TODO: currently only summing each catchment. Should we be using all upstream? That would require downloading way more catchments.
   # TODO: not all sites are mapped to COMIDs or had catchments available. We could look at using 5 km radius for site's without catchment polys.
   
-  # First, extract the catchments as polygons
-  tar_target(p2_nhdplus_catchment_sf, extract_nhdplus_geopackage_layer(p1_nhdplus_catchments_gpkg)),
+  # Each COMID and site will have a value for salt application for just the
+  # individual COMID catchment (`attr_roadSalt`) but also a total including
+  # all NHD+ catchments upstream (`attr_roadSaltCumulative`).
   
-  # Second, summarize total salt per catchment
+  # Extract the catchments as polygons and summarize total salt per catchment
+  # This includes any catchments that will only be used for upstream calculations
+  tar_target(p2_nhdplus_catchment_sf, extract_nhdplus_geopackage_layer(p1_nhdplus_catchments_gpkg)),
   tar_target(p2_nhdplus_catchment_salt, aggregate_road_salt_per_poly(road_salt_tif = p1_sb_road_salt_2015_tif, 
                                                                      polys_sf = p2_nhdplus_catchment_sf)),
   
-  # Then, map total salt for each NHD COMID catchment polygon to sites
+  # Then, map salt for each NHD COMID catchment polygon to sites and calculate cumulative road salt
   tar_target(p2_attr_roadSalt, map_catchment_roadSalt_to_site(p2_nhdplus_catchment_salt, p1_nwis_site_nhd_comid_xwalk)),
   
   ###### ATTR DATA 3: Calculate SC trend per site ######

--- a/_targets.R
+++ b/_targets.R
@@ -5,6 +5,7 @@ library(tarchetypes)
 options(tidyverse.quiet = TRUE)
 tar_option_set(
   packages = c(
+    'archive',
     'arrow',
     'dataRetrieval',
     'dtwclust',


### PR DESCRIPTION
Including all upstream salt as an additional attribute. Note that the download of catchments is still failing for one group of NHD COMIDs and I have chosen to just skip for now. I am working through the issues here: https://github.com/DOI-USGS/nhdplusTools/issues/376. 

There is now an additional attribute in the `p3_static_attributes` target called `attr_roadSaltCumulative` which represents the aggregate salt for the current site's catchment and all of the catchments upstream from it.

Below are some snapshots of the new upstream data compared to the catchment-only salt. Note that for these plots, I first filtered any site where `upstream` was missing. There are 11 sites where cumulative is the same as catchment roadSalt, meaning they are the headwaters reach (ratio == 1 in the histogram). Most sites have less than half of the cumulative upstream salt applied in their individual catchment, which is expected.

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/9eeb28de-67f8-4723-bbca-197fd9b91503)

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/1aeb2b73-7c0b-45bf-932b-a3f2e45722d7)


