### PR TITLE
Filter initial download to only include sites in the "Northeast"

### DIFF
--- a/1_Download.R
+++ b/1_Download.R
@@ -8,7 +8,9 @@ source('1_Download/src/retry_fxns.R')
 p1_targets <- list(
   
   # Define target listing the state abbreviations within the Contiguous United States (CONUS)
-  tar_target(p1_conus_state_cds, state.abb[!state.abb %in% c('AK', 'HI')]), 
+  tar_target(p1_conus_state_cds, c("CT", "DE", "IL", "IN", "IA", "KY", "ME", "MD", 
+                                   "MA", "MI", "MN", "MO", "NH", "NJ", "NY", "OH", 
+                                   "PA", "RI", "VT", "VA", "WV", "WI")), 
   
   ##### NWIS DATA: Download SC and Q {75 MIN} #####
   

--- a/1_Download.R
+++ b/1_Download.R
@@ -119,14 +119,15 @@ p1_targets <- list(
   # Separate by the service and download groups.
   # DV = daily data
   # UV = instantaneous data (downloading only if mean daily values aren't available
-  tar_target(p1_nwis_q_sites_query_uv, filter(p1_nwis_q_sites_query, query_service == 'uv')),
-  tar_target(p1_nwis_q_sites_query_uv_download_grps,
-             p1_nwis_q_sites_query_uv %>% 
-               # Set `max_results` much lower than default for `uv` because 1 day = 1440 records
-               add_download_grp(max_results = 15000) %>% 
-               group_by(task_num) %>% 
-               tar_group(),
-             iteration = 'group'),
+  # TODO: SOMEHOW HANDLE UV WHEN EMPTY?
+  # tar_target(p1_nwis_q_sites_query_uv, filter(p1_nwis_q_sites_query, query_service == 'uv')),
+  # tar_target(p1_nwis_q_sites_query_uv_download_grps,
+  #            p1_nwis_q_sites_query_uv %>% 
+  #              # Set `max_results` much lower than default for `uv` because 1 day = 1440 records
+  #              add_download_grp(max_results = 15000) %>% 
+  #              group_by(task_num) %>% 
+  #              tar_group(),
+  #            iteration = 'group'),
   tar_target(p1_nwis_q_sites_query_dv, filter(p1_nwis_q_sites_query, query_service == 'dv')),
   tar_target(p1_nwis_q_sites_query_dv_download_grps,
              p1_nwis_q_sites_query_dv %>% 
@@ -136,18 +137,18 @@ p1_targets <- list(
              iteration = 'group'),
   
   ###### NWIS DATA 8: Download the Q data and save as files in `1_Download/out_nwis` ######
-  tar_target(p1_nwis_q_data_uv_feather,
-             download_nwis_data(
-               out_file = sprintf('1_Download/out_nwis/q_uv_%03d.feather',
-                                  unique(p1_nwis_q_sites_query_uv_download_grps$task_num)),
-               site_numbers = p1_nwis_q_sites_query_uv_download_grps$site_no,
-               param_cd = p1_nwis_pcode_q,
-               start_date = p1_nwis_start_date,
-               end_date = p1_nwis_end_date,
-               service_cd = 'uv'
-             ),
-             pattern = map(p1_nwis_q_sites_query_uv_download_grps),
-             format = 'file'),
+  # tar_target(p1_nwis_q_data_uv_feather,
+  #            download_nwis_data(
+  #              out_file = sprintf('1_Download/out_nwis/q_uv_%03d.feather',
+  #                                 unique(p1_nwis_q_sites_query_uv_download_grps$task_num)),
+  #              site_numbers = p1_nwis_q_sites_query_uv_download_grps$site_no,
+  #              param_cd = p1_nwis_pcode_q,
+  #              start_date = p1_nwis_start_date,
+  #              end_date = p1_nwis_end_date,
+  #              service_cd = 'uv'
+  #            ),
+  #            pattern = map(p1_nwis_q_sites_query_uv_download_grps),
+  #            format = 'file'),
   tar_target(p1_nwis_q_data_dv_feather, 
              download_nwis_data(
                out_file = sprintf('1_Download/out_nwis/q_dv_%03d.feather', 
@@ -171,10 +172,13 @@ p1_targets <- list(
   # that may have data for parameter codes that contain `tidally filtered`
   # discharge, velocity, or gage height, indicating tidal influence
   tar_target(p1_nwis_sc_sites_tidal, 
-             whatNWISsites(siteNumber = p1_nwis_sc_sites_query$site_no,
-                           parameterCd = c("72137", "72138", "72139", "72168", 
-                                           "72169", "72170", "72171")) %>% 
-               pull(site_no)),
+             # TODO: add in method for handling when none of them have tidal influence
+             c()
+             # whatNWISsites(siteNumber = p1_nwis_sc_sites_query$site_no,
+             #               parameterCd = c("72137", "72138", "72139", "72168", 
+             #                               "72169", "72170", "72171")) %>% 
+             #   pull(site_no)
+             ),
   
   ##### SCIENCEBASE DATASET DOWNLOADS {< 1 MIN} #####
   

--- a/1_Download/src/nwis_fxns.R
+++ b/1_Download/src/nwis_fxns.R
@@ -91,12 +91,12 @@ inventory_nwis_data <- function(site_numbers, param_cd, start_date, end_date) {
     # Add other info about the data stream back in
     left_join(data_info, by = c('site_no', query_service = 'data_type_cd', 'stat_cd')) %>%  
     # Cleanup table to return
-    select(site_no, query_service, 
-           datastream_name = loc_web_ds, # This is sometimes used to distinguish multiple sensors at one site
-           begin_date, end_date, 
-           days_count = count_nu, 
-           year_span, year_coverage, 
-           gap_pct)
+    dplyr::select(site_no, query_service, 
+                  datastream_name = loc_web_ds, # This is sometimes used to distinguish multiple sensors at one site
+                  begin_date, end_date, 
+                  days_count = count_nu, 
+                  year_span, year_coverage, 
+                  gap_pct)
     
 }
 
@@ -139,7 +139,7 @@ filter_to_min_data_standards <- function(data_info, min_yrs, min_end_date) {
     filter(year_coverage >= min_yrs) %>% 
     filter(end_date >= min_end_date) %>% 
     # Need `days_count` for splitting queries for download later
-    select(site_no, query_service, days_count)
+    dplyr::select(site_no, query_service, days_count)
 }
 
 #' @title Define data download groups
@@ -173,7 +173,7 @@ add_download_grp <- function(data_info, max_results = 250000, max_sites = 2000) 
     group_by(task_num_by_group, task_num_by_results) %>% 
     mutate(task_num = cur_group_id()) %>% 
     ungroup() %>% 
-    select(site_no, task_num)
+    dplyr::select(site_no, task_num)
 }
 
 #' @title Download data from NWIS
@@ -246,7 +246,7 @@ download_nwis_data <- function(out_file, site_numbers, param_cd, start_date,
   # Rename & select certain columns + save the data as a file 
   nwis_data %>% 
     renameNWISColumns() %>% 
-    select(site_no, dateTime, contains('SpecCond'), contains('Flow')) %>%
+    dplyr::select(site_no, dateTime, contains('SpecCond'), contains('Flow')) %>%
     write_feather(out_file)
   
   return(out_file)

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -111,20 +111,21 @@ p2_targets <- list(
   ###### ATTR DATA 1: Collapse Q time series to mean Q per site ######
   
   # First, convert instantaneous Q to daily Q
-  tar_target(p2_attr_q_uv_to_dv_feather, 
-             calculate_dv_from_uv(out_file = file.path('2_Prepare/tmp/', 
-                                                       gsub('uv', 'uv_to_dv', 
-                                                            basename(p1_nwis_q_data_uv_feather))),
-                                  in_file = p1_nwis_q_data_uv_feather,
-                                  site_tz_xwalk = p1_nwis_sc_sites_metadata,
-                                  param_colname = 'Flow'),
-             pattern = map(p1_nwis_q_data_uv_feather),
-             format = 'file'),
+  # TODO: REINSTATE WHEN WE SOLVE HOW TO HANDLE WHEN THIS RETURNS NOTHING.
+  # tar_target(p2_attr_q_uv_to_dv_feather, 
+  #            calculate_dv_from_uv(out_file = file.path('2_Prepare/tmp/', 
+  #                                                      gsub('uv', 'uv_to_dv', 
+  #                                                           basename(p1_nwis_q_data_uv_feather))),
+  #                                 in_file = p1_nwis_q_data_uv_feather,
+  #                                 site_tz_xwalk = p1_nwis_sc_sites_metadata,
+  #                                 param_colname = 'Flow'),
+  #            pattern = map(p1_nwis_q_data_uv_feather),
+  #            format = 'file'),
   
   # Then, combine all daily Q
   tar_target(p2_attr_q_dv_feather, 
              combine_all_dv_data(out_file = '2_Prepare/tmp/attr_q_dv.feather',
-                                 in_files = c(p2_attr_q_uv_to_dv_feather,
+                                 in_files = c(#p2_attr_q_uv_to_dv_feather,
                                               p1_nwis_q_data_dv_feather),
                                  param_colname = 'Flow'),
              format = 'file'),

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -11,7 +11,8 @@ p6_targets <- list(
   
   ##### Prep data for RF #####
   
-  tar_target(p6_site_attr_rf, prep_attr_randomforest(p3_static_attributes, p4_episodic_sites, p5_sc_baseflow_trend)),
+  tar_target(p6_site_attr, prep_attr_randomforest(p3_static_attributes, p4_episodic_sites, p5_sc_baseflow_trend)),
+  tar_target(p6_site_attr_rf, dplyr::select(p6_site_attr, -site_no)),
   
   ##### Determine optimal RF configs #####
   

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -45,6 +45,6 @@ p6_targets <- list(
   
   ##### Visualize site category attribute distributions #####
   
-  tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal))
-  
+  tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal)),
+  tar_target(p6_category_map, visualize_catgory_sites_map(p6_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds))
 )

--- a/6_DefineCharacteristics/src/prep_attr_randomforest.R
+++ b/6_DefineCharacteristics/src/prep_attr_randomforest.R
@@ -38,8 +38,8 @@ prep_attr_randomforest <- function(site_attr_data, sites_episodic, site_baseflow
     # One site is missing road salt (did not have a catchment in NHD+) - removing
     filter(site_no != '01542500') %>% 
     
-    # Remove the columns that are not needed for the RF
-    select(site_category_fact, starts_with('attr')) %>% 
+    # Remove the columns that are not needed for the RF (except site_no)
+    select(site_no, site_category_fact, starts_with('attr')) %>% 
     # Drop the `attr_` prefix so that the results are cleaner
     rename_with(~gsub("attr_", "", .x))
   

--- a/6_DefineCharacteristics/src/visualize_attribute_distributions.R
+++ b/6_DefineCharacteristics/src/visualize_attribute_distributions.R
@@ -16,3 +16,40 @@ visualize_numeric_attrs <- function(site_attr_data) {
             subtitle = 'Note that we have not yet implemented baseflow methods') +
     theme(strip.background = element_rect(fill = 'white', color = 'transparent'))
 }
+
+# TODO: DOCUMENTATION
+add_state_basemap <- function(states_to_include) {
+  states_sf <- usmap::us_map(include = states_to_include) %>% 
+    st_as_sf(coords = c('x', 'y'), 
+             crs = usmap::usmap_crs()) %>% 
+    group_by(group, abbr) %>% 
+    summarise(geometry = st_combine(geometry), .groups="keep") %>%
+    st_cast("POLYGON")
+  
+  geom_sf(data=states_sf, fill = 'white', color = 'darkgrey')
+}
+
+# TODO: DOCUMENTATION
+visualize_catgory_sites_map <- function(site_attributes, sites_sf, states_to_include) {
+  
+  category_sites_sf <- sites_sf %>% 
+    left_join(site_attributes, by = 'site_no') %>% 
+    st_transform(crs=usmap::usmap_crs()) %>% 
+    filter(!is.na(site_category_fact)) %>% 
+    mutate(site_category = as.character(site_category_fact)) %>% 
+    group_by(site_category) %>% 
+    mutate(n_category = n()) %>% 
+    ungroup() %>% 
+    mutate(category_title = sprintf('%s (n = %s)', site_category, n_category))
+  
+  ggplot() +
+    add_state_basemap(states_to_include) +
+    geom_sf(data=category_sites_sf, 
+            aes(color = site_category_fact), 
+            alpha=0.75, shape=17, size=2) +
+    guides(color = 'none') +
+    scico::scale_color_scico_d() +
+    facet_wrap(vars(category_title), ncol=2) +
+    theme_void()
+  
+}


### PR DESCRIPTION
I used the salt raster as a way to identify what the northeast states should be. See code for how I programmatically completed the following steps.

First,  I plot the raster of salt as-is but it was rather difficult to see the delineation of what was 0 (grey) and what states had more substantial values. 

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/ece2ea3a-ac8d-48ab-a533-76eab93e5faf)

So instead, I switched to plotting any cell value above the mean as black, everything below the mean as grey. This helped me better define "northeastern" states.

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/f3f40a62-87bf-4c41-a8b1-a8ad9468d802)

I chose the bottom left corner of the Missouri bounding box as my westernmost and southernmost point. Then filtered to only states whose centers are above that location.

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/b9be0643-daad-4531-9dc9-f645d9a7aa2f)

```r
# Plot road salt raster to figure out the "Northeast"
library(raster)

road_salt_rast <- raster::raster(tar_read(p1_sb_road_salt_2015_tif))
plot(road_salt_rast)

# It was hard to see so I tried a simple black/grey
max_salt <- cellStats(road_salt_rast, max)
mean_salt <- cellStats(road_salt_rast, mean)
pal <- colorRampPalette(c("lightgrey","black"))
plot(road_salt_rast, breaks=c(0,mean_salt,max_salt), col = pal(2))

# Based on this, I will set the bottom left corner of Missouri bbox
mo_corner <- c(x = -95.642175, y = 36.699053)
is_east <- state.center$x >= mo_corner[['x']]
is_north <- state.center$y >= mo_corner[['y']]
states_northeast <- state.abb[is_east & is_north]

usmap::plot_usmap(include = states_northeast, fill='bisque2') 
```
 