### PR TITLE
Add two more random forest models & static attributes

### DIFF
--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -132,9 +132,8 @@ p2_targets <- list(
   
   # Then this Q data is filtered to only qualifying sites in `3_Filter`
   
-  # Then, find a single mean daily Q value per site
-  # TODO: do we need to do anything about negative streamflows?
-  tar_target(p2_attr_meanFlow, calculate_mean_q_per_site(p3_attr_q_qualified)),
+  # Then, calculate static attributes of daily Q value per site
+  tar_target(p2_attr_flow, calculate_q_stats_per_site(p3_attr_q_qualified)),
   
   ###### ATTR DATA 2: Extract road salt application per site ######
   
@@ -171,7 +170,7 @@ p2_targets <- list(
   
   ###### ATTR DATA 4: Combine all static attributes into one table ######
   
-  tar_target(p2_attr_all, combine_static_attributes(p2_attr_meanFlow,
+  tar_target(p2_attr_all, combine_static_attributes(p2_attr_flow,
                                                     p2_attr_roadSalt,
                                                     p2_attr_nhd,
                                                     p2_attr_trnmsv_and_depth2wt))

--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -165,11 +165,15 @@ p2_targets <- list(
                                                     p1_nwis_site_nhd_comid_xwalk)),
   
   # TODO: add GW signature? transmissivity? depth2wt?
+  tar_target(p2_attr_trnmsv_and_depth2wt, prepare_sb_gw_attrs(p1_sb_transmissivity_csv,
+                                                              p1_sb_depth2wt_csv, 
+                                                              p1_nwis_site_nhd_comid_xwalk)),
   
   ###### ATTR DATA 4: Combine all static attributes into one table ######
   
   tar_target(p2_attr_all, combine_static_attributes(p2_attr_meanFlow,
                                                     p2_attr_roadSalt,
-                                                    p2_attr_nhd))
+                                                    p2_attr_nhd,
+                                                    p2_attr_trnmsv_and_depth2wt))
   
 )

--- a/2_Prepare/src/attr_prep_fxns.R
+++ b/2_Prepare/src/attr_prep_fxns.R
@@ -175,3 +175,20 @@ prepare_nhd_attributes <- function(nhd_attribute_table, comid_site_xwalk) {
       attr_streamDensity = 'CAT_STRM_DENS')))
   
 }
+
+# TODO: DOCUMENTATION IF WE USE THIS
+prepare_sb_gw_attrs <- function(transmissivity_csv, depth2wt_csv, comid_site_xwalk) {
+  
+  trnmsv <- read_csv(transmissivity_csv, show_col_types = FALSE) %>% 
+    mutate(nhd_comid = comid) %>% 
+    select(nhd_comid, attr_transmissivity = trans250)
+  
+  dtw <- read_csv(depth2wt_csv, show_col_types = FALSE) %>% 
+    mutate(nhd_comid = comid) %>% 
+    select(nhd_comid, attr_zellSanfordDepthToWT = dtw250)
+  
+  comid_site_xwalk %>% 
+    left_join(trnmsv, by = 'nhd_comid') %>% 
+    left_join(dtw, by = 'nhd_comid') %>% 
+    select(site_no, starts_with('attr_'))
+}

--- a/2_Prepare/src/attr_prep_fxns.R
+++ b/2_Prepare/src/attr_prep_fxns.R
@@ -10,9 +10,29 @@
 #' the columns `site_no` and `attr_meanFlow`.
 #'
 calculate_mean_q_per_site <- function(data_q) {
-  data_q %>% 
+  
+  overall_q <- data_q %>% 
     group_by(site_no) %>% 
-    summarize(attr_meanFlow = mean(Flow, na.rm = TRUE))
+    summarize(attr_meanFlow = mean(Flow, na.rm = TRUE),
+              attr_medianFlow = median(Flow, na.rm = TRUE),
+              attr_iqrFlow = iqr(Flow, na.rm = TRUE))
+  # TODO: NEED TO UPDATE FUNCTION NAME TO BE MORE ABOUT GENERAL 
+  # ATTRIBUTES RELATED TO STREAM FLOW
+  seasonal_q <- data_q %>% 
+    mutate(isWinter = month(dateTime) %in% c(12, 1, 2, 3)) %>% 
+    group_by(site_no) %>% 
+    summarize(attr_meanNonWinterFlow = mean(Flow[!isWinter], na.rm = TRUE),
+              attr_meanWinterFlow = mean(Flow[isWinter], na.rm = TRUE),
+              attr_medianNonWinterFlow = median(Flow[!isWinter], na.rm = TRUE),
+              attr_medianWinterFlow = median(Flow[isWinter], na.rm = TRUE),
+              attr_maxNonWinterFlow = max(Flow[!isWinter], na.rm = TRUE),
+              attr_maxWinterFlow = max(Flow[isWinter], na.rm = TRUE),
+              attr_minNonWinterFlow = min(Flow[!isWinter], na.rm = TRUE),
+              attr_minWinterFlow = min(Flow[isWinter], na.rm = TRUE),
+              attr_iqrNonWinterFlow = iqr(Flow[!isWinter], na.rm = TRUE),
+              attr_iqrWinterFlow = iqr(Flow[isWinter], na.rm = TRUE))
+  
+  left_join(overall_q, seasonal_q, by = 'site_no')
 }
 
 #' @title Z-normalize a set of values

--- a/4_EpisodicSalinization.R
+++ b/4_EpisodicSalinization.R
@@ -28,6 +28,6 @@ p4_targets <- list(
              summarize_salt_peaks(p4_ts_sc_peaks, min_winter_perc = 0.40, min_perc_diff = 0.10)),
   tar_target(p4_episodic_sites, filter(p4_ts_sc_peak_summary, is_salt_site)$site_no)
   
-  # TODO: revisit three that are still questionable - c('02042500', '04024000', '04067500')
+  # TODO: revisit three that are still questionable - c('02042500', '04024000', '04067500', '01408000', '01650800')
   
 )

--- a/5_BaseflowSalinization.R
+++ b/5_BaseflowSalinization.R
@@ -15,8 +15,9 @@ p5_targets <- list(
   # Calculate how much of daily flow is baseflow vs quickflow using 
   # Rumsey et al 2023 methods: `FlowScreen::bf_eckhardt()` with the
   # constant `a=0.97` as suggested in Eckhardt 2012 for perennial streams
+  tar_target(p5_bfi, select(p3_static_attributes, site_no, attr_baseFlowInd)), 
   tar_target(p5_baseflow_sep, 
-             delineate_baseflow(p5_q_grp, p3_static_attributes),
+             delineate_baseflow(p5_q_grp, p5_bfi),
              pattern = map(p5_q_grp)),
   
   # Identify which site-days meet criteria for being a non-winter baseflow day

--- a/5_BaseflowSalinization/src/delineate_baseflow.R
+++ b/5_BaseflowSalinization/src/delineate_baseflow.R
@@ -1,10 +1,9 @@
 
 # TODO: documentation
-# map over `p3_attr_q_qualified` by site
-delineate_baseflow <- function(ts_q, site_attr_data) {
+delineate_baseflow <- function(ts_q, site_bfi_data) {
   
   # Use a custom input for the BFI based on known info for this site.
-  bfi <- site_attr_data %>% 
+  bfi <- site_bfi_data %>% 
     filter(site_no == unique(ts_q$site_no)) %>% 
     # Change from percent to fraction for `bf_eckhardt()`
     mutate(bfi = attr_baseFlowInd/100) %>% 
@@ -14,7 +13,7 @@ delineate_baseflow <- function(ts_q, site_attr_data) {
   # case, assume BFI is the average for the sites in this dataset ...
   # TODO: BETTER ASSUMPTION HERE
   if(is.na(bfi)) {
-    bfi <- mean(site_attr_data$attr_baseFlowInd, na.rm=T)/100
+    bfi <- mean(site_bfi_data$attr_baseFlowInd, na.rm=T)/100
   }
   
   # Use a constant for alpha as suggested by Eckhardt 2012 for perennial stream

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -133,27 +133,30 @@ p6_targets <- list(
     
     # Prep plot views for each type
     both_rf_plots <- list(
+      p6_attrs_num_viz,
       p6_rf_attr_importance_viz,
       p6_rf_attr_partdep_viz,
       p6_category_map
     )
     
     episodic_rf_plots <- list(
+      p6b_attrs_num_viz, 
       p6b_rf_attr_importance_viz,
       p6b_rf_attr_partdep_viz,
       p6b_category_map
     )
     
     baseflow_rf_plots <- list(
+      p6c_attrs_num_viz, 
       p6c_rf_attr_importance_viz,
       p6c_rf_attr_partdep_viz,
       p6c_category_map
     )
     
     pdf(out_file, width = 30, height = 15)
-    print(cowplot::plot_grid(plotlist = both_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
-    print(cowplot::plot_grid(plotlist = episodic_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
-    print(cowplot::plot_grid(plotlist = baseflow_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
+    print(cowplot::plot_grid(plotlist = both_rf_plots, nrow=2))
+    print(cowplot::plot_grid(plotlist = episodic_rf_plots, nrow=2))
+    print(cowplot::plot_grid(plotlist = baseflow_rf_plots, nrow=2))
     dev.off()
     return(out_file)
   }, format = 'file')

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -134,29 +134,30 @@ p6_targets <- list(
     # Prep plot views for each type
     both_rf_plots <- list(
       p6_attrs_num_viz,
-      p6_rf_attr_importance_viz,
       p6_rf_attr_partdep_viz,
+      p6_rf_attr_importance_viz,
       p6_category_map
     )
     
     episodic_rf_plots <- list(
       p6b_attrs_num_viz, 
-      p6b_rf_attr_importance_viz,
       p6b_rf_attr_partdep_viz,
+      p6b_rf_attr_importance_viz,
       p6b_category_map
     )
     
     baseflow_rf_plots <- list(
       p6c_attrs_num_viz, 
-      p6c_rf_attr_importance_viz,
       p6c_rf_attr_partdep_viz,
+      p6c_rf_attr_importance_viz,
       p6c_category_map
     )
     
-    pdf(out_file, width = 30, height = 15)
-    print(cowplot::plot_grid(plotlist = both_rf_plots, nrow=2))
-    print(cowplot::plot_grid(plotlist = episodic_rf_plots, nrow=2))
-    print(cowplot::plot_grid(plotlist = baseflow_rf_plots, nrow=2))
+    pdf(out_file, width = 30, height = 15) # Good monitor size
+    # pdf(out_file, width = 24, height = 17) # Printer aspect ratio
+    print(cowplot::plot_grid(plotlist = both_rf_plots, nrow=2), rel_heights = c(0.60, 0.40))
+    print(cowplot::plot_grid(plotlist = episodic_rf_plots, nrow=2), rel_heights = c(0.60, 0.40))
+    print(cowplot::plot_grid(plotlist = baseflow_rf_plots, nrow=2), rel_heights = c(0.60, 0.40))
     dev.off()
     return(out_file)
   }, format = 'file')

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -9,12 +9,14 @@ source('6_DefineCharacteristics/src/visualize_attribute_distributions.R')
 
 p6_targets <- list(
   
-  ##### Prep data for RF #####
+  ##### Run random forest for both episodic & baseflow salinization #####
+  
+  ###### Prep data for RF ######
   
   tar_target(p6_site_attr, prep_attr_randomforest(p3_static_attributes, p4_episodic_sites, p5_sc_baseflow_trend)),
   tar_target(p6_site_attr_rf, dplyr::select(p6_site_attr, -site_no)),
   
-  ##### Determine optimal RF configs #####
+  ###### Determine optimal RF configs ######
   
   tar_target(p6_rf_model_initial, apply_randomforest(p6_site_attr_rf)),
   
@@ -29,11 +31,11 @@ p6_targets <- list(
   # Now with the new site attributes re-calculate the optimal `mtry`
   tar_target(p6_mtry_optimal, optimize_mtry(p6_site_attr_rf_optimal)),
   
-  ##### Run optimal RF #####
+  ###### Run optimal RF ######
   
   tar_target(p6_rf_model_optimal, apply_randomforest(p6_site_attr_rf_optimal, p6_mtry_optimal)),
   
-  ##### Evaluate RF output #####
+  ###### Evaluate RF output ######
   
   tar_target(p6_rf_attr_importance, calculate_attr_importance(p6_rf_model_optimal)),
   tar_target(p6_rf_attr_importance_viz, visualize_attr_importance(p6_rf_attr_importance)),
@@ -43,8 +45,126 @@ p6_targets <- list(
                                                               p6_site_attr_rf)),
   tar_target(p6_rf_attr_partdep_viz, visualize_partial_dependence(p6_rf_attr_partdep)),
   
-  ##### Visualize site category attribute distributions #####
+  ###### Visualize site category attribute distributions ######
   
   tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal)),
-  tar_target(p6_category_map, visualize_catgory_sites_map(p6_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds))
+  tar_target(p6_category_map, visualize_catgory_sites_map(p6_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds)),
+  
+  ##### Run random forest for just episodic #####
+  
+  ###### Prep data for RF ######
+  
+  tar_target(p6b_site_attr, prep_attr_randomforest(p3_static_attributes, sites_episodic = p4_episodic_sites)),
+  tar_target(p6b_site_attr_rf, dplyr::select(p6b_site_attr, -site_no)),
+  
+  ###### Determine optimal RF configs ######
+  
+  tar_target(p6b_rf_model_initial, apply_randomforest(p6b_site_attr_rf)),
+  
+  # Find and use optimal `mtry` to minimize OOB error
+  tar_target(p6b_mtry_optimal_all_attrs, optimize_mtry(p6b_site_attr_rf)),
+  tar_target(p6b_rf_model_minOOB, apply_randomforest(p6b_site_attr_rf, p6b_mtry_optimal_all_attrs)),
+  
+  # Trim the number of attributes used by only choosing those that appeared as
+  # one of the top 10 most important in one of the categories.
+  tar_target(p6b_site_attr_rf_optimal, optimize_attrs(p6b_site_attr_rf, p6b_rf_model_minOOB)),
+  
+  # Now with the new site attributes re-calculate the optimal `mtry`
+  tar_target(p6b_mtry_optimal, optimize_mtry(p6b_site_attr_rf_optimal)),
+  
+  ###### Run optimal RF ######
+  
+  tar_target(p6b_rf_model_optimal, apply_randomforest(p6b_site_attr_rf_optimal, p6b_mtry_optimal)),
+  
+  ###### Evaluate RF output ######
+  
+  tar_target(p6b_rf_attr_importance, calculate_attr_importance(p6b_rf_model_optimal)),
+  tar_target(p6b_rf_attr_importance_viz, visualize_attr_importance(p6b_rf_attr_importance)),
+  tar_target(p6b_rf_attr_importance_simple_viz, visualize_attr_importance(p6b_rf_attr_importance,
+                                                                          simple = TRUE)),
+  tar_target(p6b_rf_attr_partdep, calculate_partial_dependence(p6b_rf_model_optimal, 
+                                                               p6b_site_attr_rf)),
+  tar_target(p6b_rf_attr_partdep_viz, visualize_partial_dependence(p6b_rf_attr_partdep)),
+  
+  ###### Visualize site category attribute distributions ######
+  
+  tar_target(p6b_attrs_num_viz, visualize_numeric_attrs(p6b_site_attr_rf_optimal)),
+  tar_target(p6b_category_map, visualize_catgory_sites_map(p6b_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds)),
+  
+  ##### Run random forest for just baseflow salinization #####
+  
+  ###### Prep data for RF ######
+  
+  tar_target(p6c_site_attr, prep_attr_randomforest(p3_static_attributes, site_baseflow_trend_info = p5_sc_baseflow_trend)),
+  tar_target(p6c_site_attr_rf, dplyr::select(p6c_site_attr, -site_no)),
+  
+  ###### Determine optimal RF configs ######
+  
+  tar_target(p6c_rf_model_initial, apply_randomforest(p6c_site_attr_rf)),
+  
+  # Find and use optimal `mtry` to minimize OOB error
+  tar_target(p6c_mtry_optimal_all_attrs, optimize_mtry(p6c_site_attr_rf)),
+  tar_target(p6c_rf_model_minOOB, apply_randomforest(p6c_site_attr_rf, p6c_mtry_optimal_all_attrs)),
+  
+  # Trim the number of attributes used by only choosing those that appeared as
+  # one of the top 10 most important in one of the categories.
+  tar_target(p6c_site_attr_rf_optimal, optimize_attrs(p6c_site_attr_rf, p6c_rf_model_minOOB)),
+  
+  # Now with the new site attributes re-calculate the optimal `mtry`
+  tar_target(p6c_mtry_optimal, optimize_mtry(p6c_site_attr_rf_optimal)),
+  
+  ###### Run optimal RF ######
+  
+  tar_target(p6c_rf_model_optimal, apply_randomforest(p6c_site_attr_rf_optimal, p6c_mtry_optimal)),
+  
+  ###### Evaluate RF output ######
+  
+  tar_target(p6c_rf_attr_importance, calculate_attr_importance(p6c_rf_model_optimal)),
+  tar_target(p6c_rf_attr_importance_viz, visualize_attr_importance(p6c_rf_attr_importance)),
+  tar_target(p6c_rf_attr_importance_simple_viz, visualize_attr_importance(p6c_rf_attr_importance,
+                                                                          simple = TRUE)),
+  tar_target(p6c_rf_attr_partdep, calculate_partial_dependence(p6c_rf_model_optimal, 
+                                                               p6c_site_attr_rf)),
+  tar_target(p6c_rf_attr_partdep_viz, visualize_partial_dependence(p6c_rf_attr_partdep)),
+  
+  ###### Visualize site category attribute distributions ######
+  
+  tar_target(p6c_attrs_num_viz, visualize_numeric_attrs(p6c_site_attr_rf_optimal)),
+  tar_target(p6c_category_map, visualize_catgory_sites_map(p6c_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds)),
+  
+  ##### Save PDF of all resulting RF #####
+  
+  tar_target(p6_rf_results_pdf, {
+    out_file <- '6_DefineCharacteristics/out/random_forest_results.pdf'
+    
+    # Prep plot views for each type
+    both_rf_plots <- list(
+      cowplot::plot_grid(plotlist = p6_rf_attr_importance_simple_viz[-4], nrow=1),
+      cowplot::plot_grid(plotlist = p6_rf_attr_importance_viz[-4], nrow=1),
+      p6_rf_attr_partdep_viz,
+      p6_category_map
+    )
+    
+    episodic_rf_plots <- list(
+      cowplot::plot_grid(plotlist = p6b_rf_attr_importance_simple_viz[c('Episodic','Not episodic')], nrow=1),
+      cowplot::plot_grid(plotlist = p6b_rf_attr_importance_viz[c('Episodic','Not episodic')], nrow=1),
+      p6b_rf_attr_partdep_viz,
+      p6b_category_map
+    )
+    
+    baseflow_rf_plots <- list(
+      cowplot::plot_grid(plotlist = p6c_rf_attr_importance_simple_viz[c('negative','none', 'positive')], nrow=1),
+      cowplot::plot_grid(plotlist = p6c_rf_attr_importance_viz[c('negative','none', 'positive')], nrow=1),
+      p6c_rf_attr_partdep_viz,
+      p6c_category_map
+    )
+    
+    pdf(out_file, width = 30, height = 15)
+    print(cowplot::plot_grid(plotlist = both_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
+    print(cowplot::plot_grid(plotlist = episodic_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
+    print(cowplot::plot_grid(plotlist = baseflow_rf_plots, nrow=2, rel_heights = c(0.40, 0.60)))
+    dev.off()
+    return(out_file)
+  }, format = 'file')
+  
 )

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -43,7 +43,7 @@ p6_targets <- list(
                                                                          simple = TRUE)),
   tar_target(p6_rf_attr_partdep, calculate_partial_dependence(p6_rf_model_optimal, 
                                                               p6_site_attr_rf)),
-  tar_target(p6_rf_attr_partdep_viz, visualize_partial_dependence(p6_rf_attr_partdep)),
+  tar_target(p6_rf_attr_partdep_viz, visualize_partial_dependence(p6_rf_attr_partdep, p6_site_attr_rf)),
   
   ###### Visualize site category attribute distributions ######
   
@@ -84,7 +84,7 @@ p6_targets <- list(
                                                                           simple = TRUE)),
   tar_target(p6b_rf_attr_partdep, calculate_partial_dependence(p6b_rf_model_optimal, 
                                                                p6b_site_attr_rf)),
-  tar_target(p6b_rf_attr_partdep_viz, visualize_partial_dependence(p6b_rf_attr_partdep)),
+  tar_target(p6b_rf_attr_partdep_viz, visualize_partial_dependence(p6b_rf_attr_partdep, p6b_site_attr_rf)),
   
   ###### Visualize site category attribute distributions ######
   
@@ -125,7 +125,7 @@ p6_targets <- list(
                                                                           simple = TRUE)),
   tar_target(p6c_rf_attr_partdep, calculate_partial_dependence(p6c_rf_model_optimal, 
                                                                p6c_site_attr_rf)),
-  tar_target(p6c_rf_attr_partdep_viz, visualize_partial_dependence(p6c_rf_attr_partdep)),
+  tar_target(p6c_rf_attr_partdep_viz, visualize_partial_dependence(p6c_rf_attr_partdep, p6c_site_attr_rf)),
   
   ###### Visualize site category attribute distributions ######
   

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -39,8 +39,6 @@ p6_targets <- list(
   
   tar_target(p6_rf_attr_importance, calculate_attr_importance(p6_rf_model_optimal)),
   tar_target(p6_rf_attr_importance_viz, visualize_attr_importance(p6_rf_attr_importance)),
-  tar_target(p6_rf_attr_importance_simple_viz, visualize_attr_importance(p6_rf_attr_importance,
-                                                                         simple = TRUE)),
   tar_target(p6_rf_attr_partdep, calculate_partial_dependence(p6_rf_model_optimal, 
                                                               p6_site_attr_rf)),
   tar_target(p6_rf_attr_partdep_viz, visualize_partial_dependence(p6_rf_attr_partdep, p6_site_attr_rf)),
@@ -80,8 +78,6 @@ p6_targets <- list(
   
   tar_target(p6b_rf_attr_importance, calculate_attr_importance(p6b_rf_model_optimal)),
   tar_target(p6b_rf_attr_importance_viz, visualize_attr_importance(p6b_rf_attr_importance)),
-  tar_target(p6b_rf_attr_importance_simple_viz, visualize_attr_importance(p6b_rf_attr_importance,
-                                                                          simple = TRUE)),
   tar_target(p6b_rf_attr_partdep, calculate_partial_dependence(p6b_rf_model_optimal, 
                                                                p6b_site_attr_rf)),
   tar_target(p6b_rf_attr_partdep_viz, visualize_partial_dependence(p6b_rf_attr_partdep, p6b_site_attr_rf)),
@@ -121,8 +117,6 @@ p6_targets <- list(
   
   tar_target(p6c_rf_attr_importance, calculate_attr_importance(p6c_rf_model_optimal)),
   tar_target(p6c_rf_attr_importance_viz, visualize_attr_importance(p6c_rf_attr_importance)),
-  tar_target(p6c_rf_attr_importance_simple_viz, visualize_attr_importance(p6c_rf_attr_importance,
-                                                                          simple = TRUE)),
   tar_target(p6c_rf_attr_partdep, calculate_partial_dependence(p6c_rf_model_optimal, 
                                                                p6c_site_attr_rf)),
   tar_target(p6c_rf_attr_partdep_viz, visualize_partial_dependence(p6c_rf_attr_partdep, p6c_site_attr_rf)),
@@ -139,22 +133,19 @@ p6_targets <- list(
     
     # Prep plot views for each type
     both_rf_plots <- list(
-      cowplot::plot_grid(plotlist = p6_rf_attr_importance_simple_viz[-4], nrow=1),
-      cowplot::plot_grid(plotlist = p6_rf_attr_importance_viz[-4], nrow=1),
+      p6_rf_attr_importance_viz,
       p6_rf_attr_partdep_viz,
       p6_category_map
     )
     
     episodic_rf_plots <- list(
-      cowplot::plot_grid(plotlist = p6b_rf_attr_importance_simple_viz[c('Episodic','Not episodic')], nrow=1),
-      cowplot::plot_grid(plotlist = p6b_rf_attr_importance_viz[c('Episodic','Not episodic')], nrow=1),
+      p6b_rf_attr_importance_viz,
       p6b_rf_attr_partdep_viz,
       p6b_category_map
     )
     
     baseflow_rf_plots <- list(
-      cowplot::plot_grid(plotlist = p6c_rf_attr_importance_simple_viz[c('negative','none', 'positive')], nrow=1),
-      cowplot::plot_grid(plotlist = p6c_rf_attr_importance_viz[c('negative','none', 'positive')], nrow=1),
+      p6c_rf_attr_importance_viz,
       p6c_rf_attr_partdep_viz,
       p6c_category_map
     )

--- a/6_DefineCharacteristics/src/evaluate_randomforest.R
+++ b/6_DefineCharacteristics/src/evaluate_randomforest.R
@@ -120,11 +120,21 @@ calculate_partial_dependence <- function(rf_model, site_attr_data) {
 }
 
 # TODO: DOCUMENTATION
-visualize_partial_dependence <- function(pdp_data) {
-  ggplot(pdp_data, aes(attr_val, attr_partdep, color = site_category)) +
+visualize_partial_dependence <- function(pdp_data, real_attribute_values) {
+  
+  # Use the actual values of the attributes to add a rug on the bottom so 
+  # we can tell which patterns of dependence for given attributes are 
+  # maybe just artifacts of a lack of input data.
+  real_attribute_values_to_plot <- real_attribute_values %>% 
+    pivot_longer(-site_category_fact, names_to = 'attribute', values_to = 'attr_val') %>% 
+    rename(site_category = site_category_fact) %>% 
+    filter(attribute %in% unique(pdp_data$attribute))
+    
+  ggplot(pdp_data, aes(x = attr_val, color = site_category)) +
     facet_wrap(vars(attribute), scales = 'free_x') +
-    scico::scale_color_scico_d() +
-    geom_line(linewidth = 1) +
+    scico::scale_color_scico_d(begin = 0, end = 0.75) +
+    geom_line(aes(y = attr_partdep), linewidth = 1) +
+    geom_rug(data=real_attribute_values_to_plot, sides='b') +
     theme_bw() +
     theme(strip.background = element_blank())
 }

--- a/6_DefineCharacteristics/src/evaluate_randomforest.R
+++ b/6_DefineCharacteristics/src/evaluate_randomforest.R
@@ -5,7 +5,7 @@ calculate_attr_importance <- function(rf_model) {
   rf_importance <- rf_model$importance %>% 
     as_tibble(rownames = 'attribute') %>% 
     dplyr::select(-MeanDecreaseGini, -MeanDecreaseAccuracy) %>% 
-    pivot_longer(matches('Both|Baseflow|Episodic|Neither'), 
+    pivot_longer(matches('Both|Baseflow|Episodic|Neither|negative|none|positive'), 
                  names_to = 'site_category',
                  values_to = 'importance') 
   
@@ -13,7 +13,7 @@ calculate_attr_importance <- function(rf_model) {
   rf_importance_sd <- rf_model$importanceSD %>% 
     as_tibble(rownames = 'attribute') %>% 
     dplyr::select(-MeanDecreaseAccuracy) %>% 
-    pivot_longer(matches('Both|Baseflow|Episodic|Neither'), 
+    pivot_longer(matches('Both|Baseflow|Episodic|Neither|negative|none|positive'), 
                  names_to = 'site_category',
                  values_to = 'importance_sd')
   
@@ -46,7 +46,8 @@ calculate_attr_importance <- function(rf_model) {
       attribute %in% c('vegIndAutumn', 'pctLowDev', 'pctHighDev', 'vegIndSummer',
                        'vegIndWinter', 'topoWetInd', 'vegIndSpring', 'numDams2013',
                        'roadStreamXings', 'roadDensity') ~ 'landcover',
-      attribute %in% c('meanFlow', 'avgRunoff', 'avgBasinSlope', 'avgStreamSlope') ~ 'basin',
+      grepl('Flow', attribute) ~ 'basin',
+      attribute %in% c('avgRunoff', 'avgBasinSlope', 'avgStreamSlope') ~ 'basin',
       .default = NA_character_
     ))
   

--- a/6_DefineCharacteristics/src/prep_attr_randomforest.R
+++ b/6_DefineCharacteristics/src/prep_attr_randomforest.R
@@ -1,25 +1,48 @@
 
 # TODO: documentation
-prep_attr_randomforest <- function(site_attr_data, sites_episodic, site_baseflow_trend_info) {
+prep_attr_randomforest <- function(site_attr_data, sites_episodic = NULL, site_baseflow_trend_info = NULL) {
   
-  # Filter to just those sites with positive baseflow trends
-  sites_baseflow <- site_baseflow_trend_info %>% filter(baseflowTrend == 'positive') %>% pull(site_no)
+  if(!is.null(sites_episodic) & !is.null(site_baseflow_trend_info)) {
+    # Prep attributes for running an RF based on both baseflow salinization trend & site episodic behavior
+    
+    # Filter to just those sites with positive baseflow trends
+    sites_baseflow <- site_baseflow_trend_info %>% filter(baseflowTrend == 'positive') %>% pull(site_no)
+    
+    # TODO: expand categories later by considering a combination of episodic + trend type (rather than just positive)
+    #   Both episodic and positive baseflow trend
+    #   Episodic with negative baseflow trend
+    #   Episodic without a baseflow trend
+    #   Not episodic but with positive baseflow trend
+    #   Not episodic and with negative baseflow trend
+    #   Neither episodic nor baseflow trend
+    
+    site_category_data <- site_attr_data %>% 
+      mutate(site_category = case_when(
+        site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Both',
+        site_no %in% sites_episodic & !site_no %in% sites_baseflow ~ 'Episodic',
+        !site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Baseflow',
+        TRUE ~ 'Neither'
+      ))
+    
+  } else if(is.null(sites_episodic) & !is.null(site_baseflow_trend_info)) {
+    # Prep attributes for running an RF based on only baseflow trends
+    site_category_data <- site_baseflow_trend_info %>% 
+      left_join(site_attr_data, by = 'site_no') %>% 
+      mutate(site_category = baseflowTrend)
+  } else if(!is.null(sites_episodic) & is.null(site_baseflow_trend_info)) {
+    # Prep attributes for running an RF based solely on episodic sites or not
+    site_category_data <- site_attr_data %>% 
+      mutate(site_category = case_when(
+        site_no %in% sites_episodic ~ 'Episodic',
+        !site_no %in% sites_episodic ~ 'Not episodic',
+        TRUE ~ 'Neither'
+      )) 
+  } else {
+    stop('Too many inputs are NULL. Need with `sites_episodic`, `site_baseflow_trend_info`, or both')
+  }
   
-  # TODO: expand categories later by considering a combination of episodic + trend type (rather than just positive)
-  #   Both episodic and positive baseflow trend
-  #   Episodic with negative baseflow trend
-  #   Episodic without a baseflow trend
-  #   Not episodic but with positive baseflow trend
-  #   Not episodic and with negative baseflow trend
-  #   Neither episodic nor baseflow trend
-  
-  site_attr_data %>% 
-    mutate(site_category = case_when(
-      site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Both',
-      site_no %in% sites_episodic & !site_no %in% sites_baseflow ~ 'Episodic',
-      !site_no %in% sites_episodic & site_no %in% sites_baseflow ~ 'Baseflow',
-      TRUE ~ 'Neither'
-    )) %>% 
+  # Now prepare the rest of the data by removing some attributes that we can't use right now
+  site_category_data %>% 
     # Make the site category a factor so that random forest
     # is doing classification, not regression
     mutate(site_category_fact = factor(site_category)) %>% 

--- a/6_DefineCharacteristics/src/visualize_attribute_distributions.R
+++ b/6_DefineCharacteristics/src/visualize_attribute_distributions.R
@@ -45,10 +45,10 @@ visualize_catgory_sites_map <- function(site_attributes, sites_sf, states_to_inc
   ggplot() +
     add_state_basemap(states_to_include) +
     geom_sf(data=category_sites_sf, 
-            aes(color = site_category_fact), 
-            alpha=0.75, shape=17, size=2) +
+            aes(fill = site_category_fact), 
+            alpha=0.75, shape=24, size=2) +
     guides(color = 'none') +
-    scico::scale_color_scico_d() +
+    scico::scale_fill_scico_d(begin = 0, end = 0.75) +
     facet_wrap(vars(category_title), ncol=2) +
     theme_void()
   

--- a/6_DefineCharacteristics/src/visualize_attribute_distributions.R
+++ b/6_DefineCharacteristics/src/visualize_attribute_distributions.R
@@ -4,16 +4,15 @@ visualize_numeric_attrs <- function(site_attr_data) {
   data_to_plot <- site_attr_data %>% 
     dplyr::select(site_category_fact, where(is.numeric)) %>%
     pivot_longer(cols = -site_category_fact, 
-                 names_to = 'attribute')
+                 names_to = 'attribute') 
   
   ggplot(data_to_plot, aes(x = site_category_fact, y = value)) +
     geom_boxplot(aes(fill = site_category_fact)) + 
     facet_wrap(vars(attribute), scales = 'free_y') +
     theme_bw() +
-    scico::scale_fill_scico_d() +
+    scico::scale_fill_scico_d(begin = 0, end = 0.75) +
     xlab('Site Category') + ylab('Attribute value (various scales and units)') +
-    ggtitle('Attributes by site categorization',
-            subtitle = 'Note that we have not yet implemented baseflow methods') +
+    ggtitle('Attributes by site categorization') +
     theme(strip.background = element_rect(fill = 'white', color = 'transparent'))
 }
 


### PR DESCRIPTION
This PR adds two more random forest models to `6_DefineCharacteristics` - one for just the episodic or not categories and one for just baseflow trend categories. This PR also includes code that adds more attributes - additional flow metrics and the transmissivity/depth to groundwater from Zell and Sanford 2020.

See results of all three models by running `tar_read(p6_rf_results_pdf)`. Attached is the results from this current state of the pipeline.

[random_forest_results.pdf](https://github.com/lindsayplatt/salt-modeling-data/files/14319656/random_forest_results.pdf)