### PR TITLE
Add watershed metrics & salt per sqkm

### DIFF
--- a/2_Prepare.R
+++ b/2_Prepare.R
@@ -137,11 +137,12 @@ p2_targets <- list(
   
   ###### ATTR DATA 2: Extract road salt application per site ######
   
-  # TODO: not all sites are mapped to COMIDs or had catchments available. We could look at using 5 km radius for site's without catchment polys.
+  # TODO: not all sites are mapped to COMIDs or had catchments available. 
+  # We could look at using 5 km radius for site's without catchment polys.
   
   # Each COMID and site will have a value for salt application for just the
-  # individual COMID catchment (`attr_roadSalt`) but also a total including
-  # all NHD+ catchments upstream (`attr_roadSaltCumulative`).
+  # individual COMID catchment (`attr_roadSaltPerSqKm`) but also a total including
+  # all NHD+ catchments upstream (`attr_roadSaltCumulativePerSqKm`).
   
   # Extract the catchments as polygons and summarize total salt per catchment
   # This includes any catchments that will only be used for upstream calculations
@@ -149,8 +150,14 @@ p2_targets <- list(
   tar_target(p2_nhdplus_catchment_salt, aggregate_road_salt_per_poly(road_salt_tif = p1_sb_road_salt_2015_tif, 
                                                                      polys_sf = p2_nhdplus_catchment_sf)),
   
+  # Calculate the total area of each catchment & its upstream catchements
+  tar_target(p2_attr_basinArea, calculate_catchment_areas(polys_sf = p2_nhdplus_catchment_sf,
+                                                          comid_upstream_tbl = p1_nhdplus_comids_upstream,
+                                                          comid_site_xwalk = p1_nwis_site_nhd_comid_xwalk)),
+  
   # Then, map salt for each NHD COMID catchment polygon to sites and calculate cumulative road salt
   tar_target(p2_attr_roadSalt, map_catchment_roadSalt_to_site(road_salt_comid = p2_nhdplus_catchment_salt, 
+                                                              basin_areas = p2_attr_basinArea,
                                                               comid_site_xwalk = p1_nwis_site_nhd_comid_xwalk,
                                                               comid_upstream_tbl = p1_nhdplus_comids_upstream)),
   
@@ -171,6 +178,7 @@ p2_targets <- list(
   ###### ATTR DATA 4: Combine all static attributes into one table ######
   
   tar_target(p2_attr_all, combine_static_attributes(p2_attr_flow,
+                                                    p2_attr_basinArea, 
                                                     p2_attr_roadSalt,
                                                     p2_attr_nhd,
                                                     p2_attr_trnmsv_and_depth2wt))

--- a/2_Prepare/src/attr_prep_fxns.R
+++ b/2_Prepare/src/attr_prep_fxns.R
@@ -16,18 +16,18 @@ calculate_q_stats_per_site <- function(data_q) {
   overall_q <- data_q %>% 
     group_by(site_no) %>% 
     summarize(attr_medianFlow = median(Flow, na.rm = TRUE),
-              attr_p05Flow = quantile(Flow, na.rm = TRUE, probs = 0.05),
-              attr_p95Flow = quantile(Flow, na.rm = TRUE, probs = 0.95))
+              attr_p05Flow = quantile(Flow, na.rm = TRUE, probs = 0.05, names=F),
+              attr_p95Flow = quantile(Flow, na.rm = TRUE, probs = 0.95, names=F))
   
   seasonal_q <- data_q %>% 
     mutate(isWinter = month(dateTime) %in% c(12, 1, 2, 3)) %>% 
     group_by(site_no) %>% 
     summarize(attr_medianNonWinterFlow = median(Flow[!isWinter], na.rm = TRUE),
               attr_medianWinterFlow = median(Flow[isWinter], na.rm = TRUE),
-              attr_p05NonWinterFlow = quantile(Flow[!isWinter], na.rm = TRUE, probs = 0.05),
-              attr_p95NonWinterFlow = quantile(Flow[!isWinter], na.rm = TRUE, probs = 0.95),
-              attr_p05WinterFlow = quantile(Flow[isWinter], na.rm = TRUE, probs = 0.05),
-              attr_p95WinterFlow = quantile(Flow[isWinter], na.rm = TRUE, probs = 0.95))
+              attr_p05NonWinterFlow = quantile(Flow[!isWinter], na.rm = TRUE, probs = 0.05, names=F),
+              attr_p95NonWinterFlow = quantile(Flow[!isWinter], na.rm = TRUE, probs = 0.95, names=F),
+              attr_p05WinterFlow = quantile(Flow[isWinter], na.rm = TRUE, probs = 0.05, names=F),
+              attr_p95WinterFlow = quantile(Flow[isWinter], na.rm = TRUE, probs = 0.95, names=F))
   
   left_join(overall_q, seasonal_q, by = 'site_no')
 }

--- a/3_Filter/src/ts_qualification.R
+++ b/3_Filter/src/ts_qualification.R
@@ -81,17 +81,17 @@ identify_highSC_sites <- function(ts_data) {
 
 #' @title Find sites that have zero road salt
 #' @description Use the road salt attribute data per site (summarizing road salt
-#' applied within a 5 km radius, see `aggregate_road_salt_per_site()`) to keep 
-#' only those sites that had some road salt applied nearby.
+#' applied within the NHD+ catchment, see `aggregate_road_salt_per_poly()`) to keep 
+#' only those sites that had some road salt within their catchment.
 #' 
-#' @param roadSalt_attrs a tibble with the columns `site_no`, and `attr_roadSalt`
+#' @param roadSalt_attrs a tibble with the columns `site_no`, and `attr_roadSaltPerSqKm`
 #' 
 #' @return a vector of NWIS site character strings which do not have road salt 
-#' applied within a 5 km radius and should be removed.
+#' applied within their catchment and should be removed.
 #' 
 identify_nonsalt_sites <- function(roadSalt_attrs) {
   roadSalt_attrs %>% 
-    filter(attr_roadSalt == 0) %>% 
+    filter(attr_roadSaltPerSqKm == 0) %>% 
     pull(site_no)
 }
 

--- a/6_DefineCharacteristics.R
+++ b/6_DefineCharacteristics.R
@@ -45,7 +45,8 @@ p6_targets <- list(
   
   ###### Visualize site category attribute distributions ######
   
-  tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal)),
+  tar_target(p6_attrs_num_viz, visualize_numeric_attrs(p6_site_attr)),
+  tar_target(p6_attrs_num_optimal_viz, visualize_numeric_attrs(p6_site_attr_rf_optimal)),
   tar_target(p6_category_map, visualize_catgory_sites_map(p6_site_attr, p1_nwis_sc_sites_sf, p1_conus_state_cds)),
   
   ##### Run random forest for just episodic #####

--- a/6_DefineCharacteristics/src/prep_attr_randomforest.R
+++ b/6_DefineCharacteristics/src/prep_attr_randomforest.R
@@ -55,7 +55,7 @@ prep_attr_randomforest <- function(site_attr_data, sites_episodic = NULL, site_b
     # TODO: Removing that attribute for now.
     select(-attr_streamDensity) %>% 
     # TODO: Removing upstream salt for now because too many sites are missing it
-    select(-attr_roadSaltCumulative) %>% 
+    select(-attr_roadSaltCumulativePerSqKm) %>% 
     # One site does not have a match in NHD+, so is missing all attributes - removing
     filter(site_no != '295501090190400') %>% 
     # One site is missing road salt (did not have a catchment in NHD+) - removing


### PR DESCRIPTION
This PR adds the following attributes (road salt attributes are really changes from total applied to road salt per area). It also converts road salt from the original units (lbs) to kilograms.

`attr_areaSqKm`
`attr_areaCumulativeSqKm`
`attr_areaRatio` (values near 1 mean the catchment is either near the headwaters -OR- we are missing most of the COMIDs)
`attr_roadSaltPerSqKm`
`attr_roadSaltCumulativePerSqKm`
`attr_roadSaltRatio` (values > 1 mean the catchment application rate is higher than the rest of the basin, but note that the missing areas of all upstream COMIDs will impact these)

See updated distributions of attributes (minus `attr_roadSaltCumulativePerSqKm` because we are still missing a number of NHD upstream catchments which I will try to solve separately).

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/0ab5c0fe-22a2-410e-8a4c-4bb4e8aca1b1)
