### PR TITLE
Fix missing NHD+ catchments!

### DIFF
--- a/1_Download.R
+++ b/1_Download.R
@@ -254,7 +254,7 @@ p1_targets <- list(
   # reused for the same sites:
   #   COMID 5866457 is linked to site_no '01104455' and '01104460'
   #   COMID 11079215 is linked to site_no '07381324' and '07381328'
-  tar_target(p1_nwis_site_nhd_comid_xwalk, 
+  tar_target(p1_nwis_site_nhd_comid_ALL_xwalk, 
              identify_site_comids(p1_nwis_sc_sites_sf),
              pattern = map(p1_nwis_sc_sites_sf)),
   
@@ -275,7 +275,7 @@ p1_targets <- list(
   # and CAT_NLCD19_82 is cultivated crops) to be used during `3_Filter`.
   tar_target(p1_nhdplus_attr_vals_tbl, 
              download_nhdplus_attributes(attributes = unlist(p1_nhdplus_attr_list),
-                                         comids = unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid)),
+                                         comids = unique(p1_nwis_site_nhd_comid_ALL_xwalk$nhd_comid)),
              pattern = map(p1_nhdplus_attr_list)),
   
   # Save attributes with their definitions and commit to the repo
@@ -283,12 +283,12 @@ p1_targets <- list(
              get_nhdplus_attribute_definitions(p1_nhdplus_attr_vals_tbl)),
   
   # Prepare COMIDs to download so that polygons are only downloaded and stored once
-  tar_target(p1_nhdplus_comids, na.omit(unique(p1_nwis_site_nhd_comid_xwalk$nhd_comid))),
-  tar_target(p1_nhdplus_comids_upstream, identify_upstream_comids(p1_nhdplus_comids), map(p1_nhdplus_comids)), # Identify upstream COMIDs
+  tar_target(p1_nhdplus_comids, na.omit(unique(p1_nwis_site_nhd_comid_ALL_xwalk$nhd_comid))),
+  tar_target(p1_nhdplus_comids_upstream_ALL, identify_upstream_comids(p1_nhdplus_comids), map(p1_nhdplus_comids)), # Identify upstream COMIDs
   tarchetypes::tar_group_count(p1_nhdplus_comids_grp, 
                                count = 500, # Set 500 groups to map over
                                # Create unique vector of COMIDs to download catchments only once
-                               tibble(nhd_comid = unique(c(p1_nhdplus_comids, p1_nhdplus_comids_upstream$nhd_comid_upstream)))),
+                               tibble(nhd_comid = unique(c(p1_nhdplus_comids, p1_nhdplus_comids_upstream_ALL$nhd_comid_upstream)))),
   
   # Download NHD+ catchment polygons by groups of COMIDs (should be 500 total branches with 
   # ~1235 COMIDs each). This takes slightly over two hours to download over 600k COMID catchments

--- a/2_Prepare/src/attr_prep_fxns.R
+++ b/2_Prepare/src/attr_prep_fxns.R
@@ -150,7 +150,7 @@ map_catchment_roadSalt_to_site <- function(road_salt_comid, basin_areas, comid_s
     # Now calculate road salt per area
     mutate(attr_roadSaltPerSqKm = roadSalt / attr_areaSqKm,
            attr_roadSaltCumulativePerSqKm = roadSaltCumulative / attr_areaCumulativeSqKm,
-           attr_roadSaltRatio = attr_roadSaltPerSqKm / attr_roadSaltCumulativePerSqKm) %>% 
+           attr_roadSaltRatio = roadSalt / roadSaltCumulative) %>% 
     dplyr::select(site_no, attr_roadSaltPerSqKm, attr_roadSaltCumulativePerSqKm, attr_roadSaltRatio)
 }
 

--- a/2_Prepare/src/extract_nhdplus_geopackage_layer.R
+++ b/2_Prepare/src/extract_nhdplus_geopackage_layer.R
@@ -31,11 +31,11 @@ extract_nhdplus_geopackage_layer <- function(in_files, gpkg_layer = 'CatchmentSP
     st_read(.x, gpkg_layer, quiet = TRUE) %>%
       st_transform(crs = crs_out) %>% {
         if(gpkg_layer == 'NHDFlowline_Network') {
-          # Now fix issues for the flowlines layer so that we can bind columns that are different types
-          mutate(., hwtype = ifelse(hwtype == " ", NA, hwtype)) %>% 
-            # In particular, there is a general issue where NA columns become character
-            # and should be numeric & sometimes `elevfixed` gets a value of "0" and should be numeric
-            mutate(across(where(is.character) & (where(is.na) | elevfixed), as.numeric)) 
+          # Now choose which columns we want from the flowlines layer (there are 
+          # many but some issues with data type and binding rows later, so only
+          # keep the ones that we need to avoid these potential issues).
+          select(., comid, lengthkm, streamleve, streamorde, 
+                 fromnode, tonode, areasqkm)
         } else {
           .
         }

--- a/3_Filter/src/nhd_catchments.R
+++ b/3_Filter/src/nhd_catchments.R
@@ -1,0 +1,22 @@
+
+#' @title Identify COMIDs with 0 drainage area
+#' @description Some of the COMIDs do not have drainage areas and therefore do not have 
+#' catchments. We *could* add something during the `identify_upstream_comids()`
+#' function in `1_Download` to only return COMIDs with an appropriate drainage
+#' area, but we were getting an error there (see issue linked below), so instead
+#' we will check at this step and filter out any that have 0 drainage areas. See 
+#' https://github.com/DOI-USGS/nhdplusTools/issues/376#issuecomment-1960684357
+#' This function identifies those COMIDs with no catchment area using the data
+#' stored in the flowlines spatial features downloaded from NHD+
+#' 
+#' @param nhd_flowlines_sf a spatial object with flowlines and at least the 
+#' columns `nhd_comid` and `areasqkm`, expects flowlines output from the function
+#' `extract_nhdplus_geopackage_layer()`
+#' 
+#' @returns a vector of numeric COMIDs that have no drainage area
+#' 
+identify_nonexistent_catchments <- function(nhd_flowlines_sf) {
+  nhd_flowlines_sf %>% 
+    filter(areasqkm == 0) %>% 
+    pull(nhd_comid)
+}

--- a/3_Filter/src/ts_qualification.R
+++ b/3_Filter/src/ts_qualification.R
@@ -116,7 +116,7 @@ filter_data_to_qualifying_sites <- function(site_data, keep_sites, remove_sites)
 
   message('Removing sites that did not meet temporal criteria: ', 
           sum(!unique(site_data$site_no) %in% keep_sites))
-  message('Removing additional sites that are ag/tidal/highSC/nonsalt: ',
+  message('Removing additional sites that are ag/tidal/highSC/nonsalt/missing NHD+: ',
           sum(keep_sites %in% remove_sites))
 
   site_data %>% 

--- a/6_DefineCharacteristics/src/evaluate_randomforest.R
+++ b/6_DefineCharacteristics/src/evaluate_randomforest.R
@@ -38,7 +38,7 @@ calculate_attr_importance <- function(rf_model) {
     dplyr::select(attribute, site_category, everything()) %>% 
     mutate(attribute_grp = case_when(
       attribute %in% c('annualPrecip', 'avgSnow', 'freezeDayFirst', 'freezeDayLast') ~ 'meteo',
-      attribute %in% c('roadSaltPerSqKm', 'roadSaltRatio') ~ 'salt',
+      attribute %in% c('roadSaltPerSqKm', 'roadSaltCumulativePerSqKm', 'roadSaltRatio') ~ 'salt',
       attribute %in% c('avgDepth2WT', 'avgGWRecharge', 'baseFlowInd',
                        'soilPerm', 'subsurfaceContact', 'zellSanfordDepthToWT') ~ 'gw',
       attribute %in% c('pctAgriculture', 'pctDeveloped', 'pctForested', 

--- a/6_DefineCharacteristics/src/prep_attr_randomforest.R
+++ b/6_DefineCharacteristics/src/prep_attr_randomforest.R
@@ -46,16 +46,6 @@ prep_attr_randomforest <- function(site_attr_data, sites_episodic = NULL, site_b
     # Make the site category a factor so that random forest
     # is doing classification, not regression
     mutate(site_category_fact = factor(site_category)) %>% 
-    
-    # TODO: Figure out better way to handle missing data below.
-    
-    # TODO: Removing upstream salt for now because too many sites are missing it
-    select(-attr_roadSaltCumulativePerSqKm) %>% 
-    # One site does not have a match in NHD+, so is missing all attributes - removing
-    filter(site_no != '295501090190400') %>% 
-    # One site is missing road salt (did not have a catchment in NHD+) - removing
-    filter(site_no != '01542500') %>% 
-    
     # Remove the columns that are not needed for the RF (except site_no)
     select(site_no, site_category_fact, starts_with('attr')) %>% 
     # Drop the `attr_` prefix so that the results are cleaner


### PR DESCRIPTION
Ultimately, the missing data for the 7,428 missing NHD+ catchment polygons for upstream COMIDs (and for 1 COMID that corresponded to a site in our data) was due to COMIDs with drainage areas of 0. Still confused about why this happens but something to do with how NHD+ works (they are all super small, so deciding it is OK to ignore).

This function filters out those problematic COMIDs so that the code and models can continue without them. Ultimately, 1 site (`01542500`) was removed from the dataset during this process. Also, the cumulative road salt value is now able to be used in the model because we have all available upstream catchment areas accounted for. Histograms of road salt for the catchment per sq km, road salt for the full upstream watershed per sq km, and the ratio of total salt applied in a catchment to the total upstream salt (1 = catchment has all salt applied, likely a headwater site).

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/48b2e5d5-462c-48b9-8f00-3da7979c3595)

![image](https://github.com/lindsayplatt/salt-modeling-data/assets/13220910/38c12e85-6ef3-442f-93e5-c9c60a47dc81)

<details>
<summary>Code for these histograms</summary>

```r
library(targets)
library(tidyverse)
tar_load(p3_static_attributes)

p3_static_attributes %>% 
    dplyr::select(site_no, `Catchment Salt` = attr_roadSaltPerSqKm,
                  `Upstream Salt` = attr_roadSaltCumulativePerSqKm) %>% 
    pivot_longer(-site_no, names_to = 'salt_calc') %>% 
    ggplot() +
    geom_histogram(aes(value, fill = salt_calc)) +
    facet_grid(salt_calc ~ .) +
    theme_bw()
ggplot(p3_static_attributes) +
    geom_histogram(aes(attr_roadSaltRatio)) + 
    xlab('Ratio of catchment salt to total cumulative upstream') +
    theme_bw()
```

</summary>